### PR TITLE
downgrade to python 3.6 in conda environment

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.7
+  - python=3.6
   - pip
   # For packaging, and testing
   - flake8


### PR DESCRIPTION
Docker runtime is python 3.6.9, setup.py specifies 3.6