### PR TITLE
Add dem_name option for RTC supporting copernicus or legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+* Option for RTC_GAMMA jobs to use either Copernicus GLO-30 Public DEM or legacy SRTM/NED DEMs for processing:
+  * `--dem-name` option to `rtc` entrypoint and `rtc_sentinel.py` script
+  * `dem_name` parameter to `hyp3_gamma.rtc_sentinel.rtc_sentinel_gamma()`
 * `hyp3_gamma.dem` module for preparing GeoTIFF mosaics of the
   [Copernicus GLO-30 Public DEM](https://registry.opendata.aws/copernicus-dem/)
 
 ### Changed
-* `rtc_sentinel.py` now leverages the [Copernicus GLO-30 Public DEM](https://registry.opendata.aws/copernicus-dem/)
-  for RTC processing.
 * Upgraded to hyp3-metadata [v0.4.0](https://github.com/ASFHyP3/hyp3-metadata-templates/blob/develop/CHANGELOG.md#040)
   from v0.2.0
 

--- a/hyp3_gamma/__main__.py
+++ b/hyp3_gamma/__main__.py
@@ -47,6 +47,7 @@ def rtc():
     parser.add_argument('--include-inc-map', type=string_is_true, default=False)
     parser.add_argument('--include-scattering-area', type=string_is_true, default=False)
     parser.add_argument('--include-rgb', type=string_is_true, default=False)
+    parser.add_argument('--dem-name', choices=['copernicus', 'legacy'], default='copernicus')
     parser.add_argument('granule')
     args = parser.parse_args()
 
@@ -68,6 +69,7 @@ def rtc():
                         include_inc_map=args.include_inc_map,
                         include_scattering_area=args.include_scattering_area,
                         include_rgb=args.include_rgb,
+                        dem_name=args.dem_name,
                     )
     output_zip = make_archive(base_name=product_name, format='zip', base_dir=product_name)
 

--- a/hyp3_gamma/rtc/rtc_sentinel.py
+++ b/hyp3_gamma/rtc/rtc_sentinel.py
@@ -13,10 +13,11 @@ from secrets import token_hex
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 from hyp3_metadata import create_metadata_file_set
-from hyp3lib import ExecuteError, GranuleError, OrbitDownloadError
+from hyp3lib import DemError, ExecuteError, GranuleError, OrbitDownloadError
 from hyp3lib.byteSigmaScale import byteSigmaScale
 from hyp3lib.createAmp import createAmp
 from hyp3lib.execute import execute
+from hyp3lib.getDemFor import getDemFile
 from hyp3lib.getParameter import getParameter
 from hyp3lib.get_orb import downloadSentinelOrbitFile
 from hyp3lib.makeAsfBrowse import makeAsfBrowse
@@ -24,6 +25,7 @@ from hyp3lib.make_cogs import cogify_dir
 from hyp3lib.raster_boundary2shape import raster_boundary2shape
 from hyp3lib.rtc2color import rtc2color
 from hyp3lib.system import gamma_version
+from hyp3lib.utm2dem import utm2dem
 from osgeo import gdal, gdalconst
 
 import hyp3_gamma
@@ -230,7 +232,7 @@ def append_additional_log_files(log_file, pattern):
 def rtc_sentinel_gamma(safe_dir: str, resolution: float = 30.0, radiometry: str = 'gamma0', scale: str = 'power',
                        speckle_filter: bool = False, dem_matching: bool = False, include_dem: bool = False,
                        include_inc_map: bool = False, include_scattering_area: bool = False, include_rgb: bool = False,
-                       looks: int = None, skip_cross_pol: bool = False) -> str:
+                       looks: int = None, skip_cross_pol: bool = False, dem_name: str = 'copernicus') -> str:
     """Creates a Radiometrically Terrain-Corrected (RTC) product from a Sentinel-1 scene using GAMMA software.
 
     Args:
@@ -248,6 +250,7 @@ def rtc_sentinel_gamma(safe_dir: str, resolution: float = 30.0, radiometry: str 
         looks: Number of azimuth looks to take. Will be selected automatically if not specified.  Range and filter looks
             are selected automatically based on azimuth looks and product type.
         skip_cross_pol: Do not include the co-polarization backscatter GeoTIFF in the output package.
+        dem_name: DEM to use for RTC processing; `copernicus` or `legacy`.
 
     Returns:
         product_name: Name of the output product directory
@@ -275,14 +278,20 @@ def rtc_sentinel_gamma(safe_dir: str, resolution: float = 30.0, radiometry: str 
                    include_scattering_area, include_rgb, orbit_file, product_name)
 
     log.info('Preparing DEM')
-    dem_type = 'COP30'
+    dem_tif = 'dem.tif'
     dem_image = 'dem.image'
     dem_par = 'dem.par'
-    geometry = get_geometry_from_kml(f'{safe_dir}/preview/map-overlay.kml')
-    with NamedTemporaryFile() as dem_tif:
-        prepare_dem_geotiff(dem_tif.name, geometry)
-        run(f'dem_import {dem_tif.name} {dem_image} {dem_par} - - $DIFF_HOME/scripts/egm2008-5.dem '
+    if dem_name == 'copernicus':
+        dem_type = 'COP30'
+        geometry = get_geometry_from_kml(f'{safe_dir}/preview/map-overlay.kml')
+        prepare_dem_geotiff(dem_tif, geometry)
+        run(f'dem_import {dem_tif} {dem_image} {dem_par} - - $DIFF_HOME/scripts/egm2008-5.dem '
             f'$DIFF_HOME/scripts/egm2008-5.dem_par - - - 1')
+    elif dem_name == 'legacy':
+        dem, dem_type = getDemFile(safe_dir, dem_tif, post=30.0)
+        run(f'dem_import {dem_tif} {dem_image} {dem_par}')
+    else:
+        raise DemError(f'DEM name "{dem_name}" is invalid; supported options are "copernicus" and "legacy".')
 
     for pol in polarizations:
         mli_image, mli_par = prepare_mli_image(safe_dir, granule_type, pol, orbit_file, looks)
@@ -402,6 +411,8 @@ def main():
     parser.add_argument('--looks', type=int,
                         help='Number of azimuth looks to take. Will be selected automatically if not specified.  Range '
                              'and filter looks are selected automatically based on azimuth looks and product type.')
+    parser.add_argument('--dem-name', choices=('copernicus', 'legacy'), default='copernicus',
+                        help='DEM to use for RTC processing')
     args = parser.parse_args()
 
     logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
@@ -425,7 +436,8 @@ def main():
                        include_scattering_area=args.include_scattering_area,
                        include_rgb=args.include_rgb,
                        looks=args.looks,
-                       skip_cross_pol=args.skip_cross_pol)
+                       skip_cross_pol=args.skip_cross_pol,
+                       dem_name=args.dem_name)
 
     log.info('===================================================================')
     log.info('                Sentinel RTC Program - Completed')

--- a/hyp3_gamma/rtc/rtc_sentinel.py
+++ b/hyp3_gamma/rtc/rtc_sentinel.py
@@ -25,7 +25,6 @@ from hyp3lib.make_cogs import cogify_dir
 from hyp3lib.raster_boundary2shape import raster_boundary2shape
 from hyp3lib.rtc2color import rtc2color
 from hyp3lib.system import gamma_version
-from hyp3lib.utm2dem import utm2dem
 from osgeo import gdal, gdalconst
 
 import hyp3_gamma

--- a/hyp3_gamma/util.py
+++ b/hyp3_gamma/util.py
@@ -55,7 +55,12 @@ def earlier_granule_first(g1, g2):
     return g2, g1
 
 
-def set_pixel_as_point(tif_file):
+def set_pixel_as_point(tif_file, shift_origin=False):
     ds = gdal.Open(tif_file, gdal.GA_Update)
     ds.SetMetadataItem('AREA_OR_POINT', 'Point')
+    if shift_origin:
+        transform = list(ds.GetGeoTransform())
+        transform[0] += transform[1] / 2
+        transform[3] += transform[5] / 2
+        ds.SetGeoTransform(transform)
     del ds

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -80,3 +80,16 @@ def test_set_pixel_as_point(tmp_path, test_data_dir):
     del area_info['metadata']['']['AREA_OR_POINT']
     del point_info['metadata']['']['AREA_OR_POINT']
     assert area_info == point_info
+
+
+def test_set_pixel_as_point_with_shift(tmp_path, test_data_dir):
+    shutil.copy(test_data_dir / 'test_geotiff.tif', tmp_path)
+    geotiff = str(tmp_path / 'test_geotiff.tif')
+    area_info = gdal.Info(geotiff, format='json')
+    assert area_info['metadata']['']['AREA_OR_POINT'] == 'Area'
+    assert area_info['geoTransform'] == [440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0]
+
+    util.set_pixel_as_point(geotiff, shift_origin=True)
+    point_info = gdal.Info(geotiff, format='json')
+    assert point_info['metadata']['']['AREA_OR_POINT'] == 'Point'
+    assert point_info['geoTransform'] == [440750.0, 60.0, 0.0, 3751290.0, 0.0, -60.0]


### PR DESCRIPTION
`--dem-name legacy S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8` passes golden testing compared to `main` (with all other parameters as the defaults).

Similarly, `--dem-name copernicus S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8` passes golden testing compared to `develop`.