### PR TITLE
restore --dem and --bbox options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,6 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Upgraded to hyp3-metadata [v0.4.0](https://github.com/ASFHyP3/hyp3-metadata-templates/blob/develop/CHANGELOG.md#040)
   from v0.2.0
 
-### Removed
-* Options to provide a custom DEM GeoTIFF or DEM bounding box have been removed:
-  * `dem` and `bbox` parameters of `rtc_sentinel.rtc_sentinel_gamma()`
-  * `--dem` and `--bbox` parameters of `rtc_sentinel.py`
-
 ##  [4.1.2](https://github.com/ASFHyP3/hyp3-gamma/compare/v4.1.1...v4.1.2)
 
 ### Changed

--- a/hyp3_gamma/rtc/rtc_sentinel.py
+++ b/hyp3_gamma/rtc/rtc_sentinel.py
@@ -294,7 +294,7 @@ def rtc_sentinel_gamma(safe_dir: str, resolution: float = 30.0, radiometry: str 
         looks: Number of azimuth looks to take. Will be selected automatically if not specified.  Range and filter looks
             are selected automatically based on azimuth looks and product type.
         skip_cross_pol: Do not include the co-polarization backscatter GeoTIFF in the output package.
-        dem_name: DEM to use for RTC processing; `copernicus` or `legacy`.
+        dem_name: DEM to use for RTC processing; `copernicus` or `legacy`. `dem_name` is ignored if `dem` is provided.
 
     Returns:
         product_name: Name of the output product directory
@@ -442,14 +442,15 @@ def main():
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--dem', help='Path to the DEM to use for RTC processing. Must be a GeoTIFF in a UTM projection.'
                                      ' A DEM will be selected automatically if not provided.')
-    group.add_argument('--bbox', type=float, nargs=4, metavar=('LON_MIN', 'LAT_MIN', 'LON_MAX', 'LAT_MAX'),
-                       help='Subset the output images to the given lat/lon bounding box.')
+    group.add_argument('--dem-name', choices=('copernicus', 'legacy'), default='copernicus',
+                       help='DEM to use for RTC processing.')
 
+    parser.add_argument('--bbox', type=float, nargs=4, metavar=('LON_MIN', 'LAT_MIN', 'LON_MAX', 'LAT_MAX'),
+                        help='Subset the output images to the given lat/lon bounding box. Ignored if --dem is '
+                             'provided.')
     parser.add_argument('--looks', type=int,
                         help='Number of azimuth looks to take. Will be selected automatically if not specified.  Range '
                              'and filter looks are selected automatically based on azimuth looks and product type.')
-    parser.add_argument('--dem-name', choices=('copernicus', 'legacy'), default='copernicus',
-                        help='DEM to use for RTC processing')
     args = parser.parse_args()
 
     logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',

--- a/hyp3_gamma/rtc/rtc_sentinel.py
+++ b/hyp3_gamma/rtc/rtc_sentinel.py
@@ -11,6 +11,7 @@ from math import isclose
 from pathlib import Path
 from secrets import token_hex
 from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import List
 
 from hyp3_metadata import create_metadata_file_set
 from hyp3lib import DemError, ExecuteError, GranuleError, OrbitDownloadError
@@ -19,6 +20,7 @@ from hyp3lib.createAmp import createAmp
 from hyp3lib.execute import execute
 from hyp3lib.getDemFor import getDemFile
 from hyp3lib.getParameter import getParameter
+from hyp3lib.get_dem import get_dem
 from hyp3lib.get_orb import downloadSentinelOrbitFile
 from hyp3lib.makeAsfBrowse import makeAsfBrowse
 from hyp3lib.make_cogs import cogify_dir
@@ -26,7 +28,7 @@ from hyp3lib.raster_boundary2shape import raster_boundary2shape
 from hyp3lib.rtc2color import rtc2color
 from hyp3lib.system import gamma_version
 from hyp3lib.utm2dem import utm2dem
-from osgeo import gdal, gdalconst
+from osgeo import gdal, gdalconst, ogr
 
 import hyp3_gamma
 from hyp3_gamma.dem import get_geometry_from_kml, prepare_dem_geotiff
@@ -35,6 +37,7 @@ from hyp3_gamma.util import set_pixel_as_point, unzip_granule
 
 log = logging.getLogger()
 gdal.UseExceptions()
+ogr.UseExceptions()
 
 
 def get_product_name(granule_name, orbit_file=None, resolution=30.0, radiometry='gamma0', scale='power',
@@ -125,6 +128,40 @@ def get_polarizations(safe_dir, skip_cross_pol=True):
 
 def run(cmd):
     execute(cmd, uselogging=True)
+
+
+def prepare_dem(safe_dir: str, dem_name: str, bbox: List[float] = None, dem: str = None):
+    dem_tif = 'dem.tif'
+    dem_type = 'UNKNOWN'
+    dem_image = 'dem.image'
+    dem_par = 'dem.par'
+
+    if dem:
+        run(f'dem_import {dem} {dem_image} {dem_par} - - $DIFF_HOME/scripts/egm2008-5.dem '
+            f'$DIFF_HOME/scripts/egm2008-5.dem_par')
+
+    elif dem_name == 'copernicus':
+        dem_type = 'COP30'
+        if bbox:
+            wkt = f'POLYGON (({bbox[0]} {bbox[3]}, {bbox[2]} {bbox[3]}, {bbox[2]} {bbox[1]}, {bbox[0]} {bbox[1]}))'
+            geometry = ogr.CreateGeometryFromWkt(wkt)
+        else:
+            geometry = get_geometry_from_kml(f'{safe_dir}/preview/map-overlay.kml')
+        prepare_dem_geotiff(dem_tif, geometry)
+        run(f'dem_import {dem_tif} {dem_image} {dem_par} - - $DIFF_HOME/scripts/egm2008-5.dem '
+            f'$DIFF_HOME/scripts/egm2008-5.dem_par - - - 1')
+
+    elif dem_name == 'legacy':
+        if bbox:
+            dem_type = get_dem(bbox[0], bbox[1], bbox[2], bbox[3], dem_tif, post=30.0)
+        else:
+            dem, dem_type = getDemFile(safe_dir, dem_tif, post=30.0)
+        utm2dem(dem_tif, dem_image, dem_par)
+
+    else:
+        raise DemError(f'DEM name "{dem_name}" is invalid; supported options are "copernicus" and "legacy".')
+
+    return dem_image, dem_par, dem_type
 
 
 def prepare_mli_image(safe_dir, granule_type, pol, orbit_file, looks):
@@ -233,7 +270,8 @@ def append_additional_log_files(log_file, pattern):
 def rtc_sentinel_gamma(safe_dir: str, resolution: float = 30.0, radiometry: str = 'gamma0', scale: str = 'power',
                        speckle_filter: bool = False, dem_matching: bool = False, include_dem: bool = False,
                        include_inc_map: bool = False, include_scattering_area: bool = False, include_rgb: bool = False,
-                       looks: int = None, skip_cross_pol: bool = False, dem_name: str = 'copernicus') -> str:
+                       dem: str = None, bbox: List[float] = None, looks: int = None, skip_cross_pol: bool = False,
+                       dem_name: str = 'copernicus') -> str:
     """Creates a Radiometrically Terrain-Corrected (RTC) product from a Sentinel-1 scene using GAMMA software.
 
     Args:
@@ -248,6 +286,10 @@ def rtc_sentinel_gamma(safe_dir: str, resolution: float = 30.0, radiometry: str 
         include_scattering_area: Include the local scattering area GeoTIFF in the output package.
         include_rgb: Include an RGB decomposition GeoTIFF in the output package.  This setting is ignored when
             processing a single-polarization product or when `skip_cross_pol` is selected.
+        dem: Path to the DEM to use for RTC processing. Must be a format accepted by dem_import. A DEM will be selected
+            automatically if not provided.
+        bbox: Subset the output images to the given lat/lon bounding box: `[lon_min, lat_min, lon_max, lat_max]`.
+            `bbox` is ignored if `dem` is provided.
         looks: Number of azimuth looks to take. Will be selected automatically if not specified.  Range and filter looks
             are selected automatically based on azimuth looks and product type.
         skip_cross_pol: Do not include the co-polarization backscatter GeoTIFF in the output package.
@@ -279,20 +321,7 @@ def rtc_sentinel_gamma(safe_dir: str, resolution: float = 30.0, radiometry: str 
                    include_scattering_area, include_rgb, orbit_file, product_name, dem_name)
 
     log.info('Preparing DEM')
-    dem_tif = 'dem.tif'
-    dem_image = 'dem.image'
-    dem_par = 'dem.par'
-    if dem_name == 'copernicus':
-        dem_type = 'COP30'
-        geometry = get_geometry_from_kml(f'{safe_dir}/preview/map-overlay.kml')
-        prepare_dem_geotiff(dem_tif, geometry)
-        run(f'dem_import {dem_tif} {dem_image} {dem_par} - - $DIFF_HOME/scripts/egm2008-5.dem '
-            f'$DIFF_HOME/scripts/egm2008-5.dem_par - - - 1')
-    elif dem_name == 'legacy':
-        dem, dem_type = getDemFile(safe_dir, dem_tif, post=30.0)
-        utm2dem(dem_tif, dem_image, dem_par)
-    else:
-        raise DemError(f'DEM name "{dem_name}" is invalid; supported options are "copernicus" and "legacy".')
+    dem_image, dem_par, dem_type = prepare_dem(safe_dir, dem_name, bbox, dem)
 
     for pol in polarizations:
         mli_image, mli_par = prepare_mli_image(safe_dir, granule_type, pol, orbit_file, looks)
@@ -409,6 +438,12 @@ def main():
     group.add_argument('--skip-cross-pol', action='store_true',
                        help='Do not include the co-polarization backscatter GeoTIFF in the output package.')
 
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--dem', help='Path to the DEM to use for RTC processing. Must be a format accepted by '
+                                     'dem_import. A DEM will be selected automatically if not provided.')
+    group.add_argument('--bbox', type=float, nargs=4, metavar=('LON_MIN', 'LAT_MIN', 'LON_MAX', 'LAT_MAX'),
+                       help='Subset the output images to the given lat/lon bounding box.')
+
     parser.add_argument('--looks', type=int,
                         help='Number of azimuth looks to take. Will be selected automatically if not specified.  Range '
                              'and filter looks are selected automatically based on azimuth looks and product type.')
@@ -436,6 +471,8 @@ def main():
                        include_inc_map=args.include_inc_map,
                        include_scattering_area=args.include_scattering_area,
                        include_rgb=args.include_rgb,
+                       dem=args.dem,
+                       bbox=args.bbox,
                        looks=args.looks,
                        skip_cross_pol=args.skip_cross_pol,
                        dem_name=args.dem_name)

--- a/hyp3_gamma/rtc/rtc_sentinel.py
+++ b/hyp3_gamma/rtc/rtc_sentinel.py
@@ -287,7 +287,7 @@ def rtc_sentinel_gamma(safe_dir: str, resolution: float = 30.0, radiometry: str 
         include_scattering_area: Include the local scattering area GeoTIFF in the output package.
         include_rgb: Include an RGB decomposition GeoTIFF in the output package.  This setting is ignored when
             processing a single-polarization product or when `skip_cross_pol` is selected.
-        dem: Path to the DEM to use for RTC processing. Must be a format accepted by dem_import. A DEM will be selected
+        dem: Path to the DEM to use for RTC processing. Must be a GeoTIFF in a UTM projection. A DEM will be selected
             automatically if not provided.
         bbox: Subset the output images to the given lat/lon bounding box: `[lon_min, lat_min, lon_max, lat_max]`.
             `bbox` is ignored if `dem` is provided.
@@ -440,8 +440,8 @@ def main():
                        help='Do not include the co-polarization backscatter GeoTIFF in the output package.')
 
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--dem', help='Path to the DEM to use for RTC processing. Must be a format accepted by '
-                                     'dem_import. A DEM will be selected automatically if not provided.')
+    group.add_argument('--dem', help='Path to the DEM to use for RTC processing. Must be a GeoTIFF in a UTM projection.'
+                                     ' A DEM will be selected automatically if not provided.')
     group.add_argument('--bbox', type=float, nargs=4, metavar=('LON_MIN', 'LAT_MIN', 'LON_MAX', 'LAT_MAX'),
                        help='Subset the output images to the given lat/lon bounding box.')
 

--- a/hyp3_gamma/rtc/rtc_sentinel.py
+++ b/hyp3_gamma/rtc/rtc_sentinel.py
@@ -143,7 +143,8 @@ def prepare_dem(safe_dir: str, dem_name: str, bbox: List[float] = None, dem: str
     elif dem_name == 'copernicus':
         dem_type = 'COP30'
         if bbox:
-            wkt = f'POLYGON (({bbox[0]} {bbox[3]}, {bbox[2]} {bbox[3]}, {bbox[2]} {bbox[1]}, {bbox[0]} {bbox[1]}))'
+            wkt = f'POLYGON (({bbox[0]} {bbox[3]}, {bbox[2]} {bbox[3]}, {bbox[2]} {bbox[1]}, {bbox[0]} {bbox[1]}, ' \
+                  f'{bbox[0]} {bbox[3]}))'
             geometry = ogr.CreateGeometryFromWkt(wkt)
         else:
             geometry = get_geometry_from_kml(f'{safe_dir}/preview/map-overlay.kml')


### PR DESCRIPTION
`--dem-name legacy S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8` passes golden testing compared to `main` (with all other parameters as the defaults)

`--bbox -92 14.2 -91.85 14.35 --dem-name legacy S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8.SAFE` passes compared to `main`

`--dem-name copernicus S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8` passes compared to `develop`

`--bbox` with `--dem-name copernicus` doesn't subset to the exact bbox like with `--dem-name legacy`, but will limit the dem mosaic to tiles within 0.15 degrees of the bbox.

`--dem` now feeds the GeoTIFF through `dem_import` with EGM2008 correction and the default NoData parameters.  Still requires a UTM projection (or at least something with a pixel size in meters, not degrees), or processing fails with `mk_geo_radcal2: ERROR calloc_2d: memory allocation error for data values` (since `mk_geo_radcal2` is called with a resolution of `30.0`).