### PR TITLE
zero-fill Copernicus DEM to extent of input geometry

### DIFF
--- a/hyp3_gamma/dem.py
+++ b/hyp3_gamma/dem.py
@@ -4,7 +4,6 @@ from subprocess import PIPE, run
 from tempfile import TemporaryDirectory
 from typing import Generator, List
 
-from hyp3lib import DemError
 from osgeo import gdal, ogr
 
 from hyp3_gamma.util import GDALConfigManager

--- a/hyp3_gamma/rtc/rtc_sentinel.py
+++ b/hyp3_gamma/rtc/rtc_sentinel.py
@@ -148,7 +148,7 @@ def prepare_dem(safe_dir: str, dem_name: str, bbox: List[float] = None, dem: str
             geometry = ogr.CreateGeometryFromWkt(wkt)
         else:
             geometry = get_geometry_from_kml(f'{safe_dir}/preview/map-overlay.kml')
-        prepare_dem_geotiff(dem_tif, geometry)
+        prepare_dem_geotiff(dem_tif, geometry.Buffer(0.15), pixel_size=30.0)
         run(f'dem_import {dem_tif} {dem_image} {dem_par} - - $DIFF_HOME/scripts/egm2008-5.dem '
             f'$DIFF_HOME/scripts/egm2008-5.dem_par - - - 1')
 

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -1,7 +1,5 @@
 import json
 
-import pytest
-from hyp3lib import DemError
 from osgeo import gdal, ogr
 
 from hyp3_gamma import dem


### PR DESCRIPTION
This is intended to implement geocoding during RTC in regions where no DEM is available.  Only implemented for when `dem_name='copernicus'`.

Doesn't (yet) play nicely with Copernicus for InSAR (https://github.com/ASFHyP3/hyp3-gamma/pull/235). I imagine InSAR jobs won't want to zero-fill areas where no DEM is available, and still raise an error when no DEM coverage is available at all.