### PR TITLE
expose include_wrapped_phase option for InSAR in hyp3 entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.1]
+
+### Added
+* `--include-wrapped-phase` option for the `insar` entrypoint to include the wrapped phase GeoTIFF in the output product
+
+### Changed
+* Updated the description of the Wrapped Interferogram in the InSAR product README, including the optional GeoTIFF
+
 ## [4.5.0]
 
 ### Added

--- a/hyp3_gamma/__main__.py
+++ b/hyp3_gamma/__main__.py
@@ -93,6 +93,7 @@ def insar():
     parser.add_argument('--include-dem', type=string_is_true, default=False)
     parser.add_argument('--include-look-vectors', type=string_is_true, default=False)
     parser.add_argument('--include-los-displacement', type=string_is_true, default=False)
+    parser.add_argument('--include-wrapped-phase', type=string_is_true, default=False)
     parser.add_argument('--include-inc-map', type=string_is_true, default=False)
     parser.add_argument('--looks', choices=['20x4', '10x2'], default='20x4')
     parser.add_argument('granules', type=str.split, nargs='+')
@@ -121,6 +122,7 @@ def insar():
         include_dem=args.include_dem,
         include_look_vectors=args.include_look_vectors,
         include_los_displacement=args.include_los_displacement,
+        include_wrapped_phase=args.include_wrapped_phase,
         include_inc_map=args.include_inc_map,
     )
 

--- a/hyp3_gamma/insar/etc/README_InSAR_GAMMA.txt
+++ b/hyp3_gamma/insar/etc/README_InSAR_GAMMA.txt
@@ -50,7 +50,7 @@ https://www.gamma-rs.ch
 
 The files generated in this process include:
 
-1. Wrapped Interferogram (PNG images, KMZ file)
+1. Wrapped Interferogram (PNG images, KMZ file, GeoTIFF (*optional*))
 2. Unwrapped Interferogram (GeoTIFF, PNG images, KMZ file)
 3. Line-of-Sight Displacement Map (GeoTIFF) - *Optional*
 4. Vertical Displacement Map (GeoTIFF)
@@ -66,11 +66,11 @@ The files generated in this process include:
 ----------------
 ## 1. Wrapped Interferogram
 
-The wrapped interferogram is output in both a georeferenced PNG and KMZ format. Because the fringes are on a wrapped 2-pi scale rather than representing continuous values, a wrapped interferogram is most useful as a visualization. This product displays deformation in multiples of half of the sensor wavelength, so areas with fringes that are very close together indicate greater amounts of deformation in the line-of-sight direction from the sensor.
+The wrapped interferogram is output in both a georeferenced PNG and KMZ format by default, and the full GeoTIFF file can also be optionally included. Because the fringes are on a wrapped 2-pi scale rather than representing continuous values, a wrapped interferogram tends to be most useful as a color visualization. This product displays deformation in multiples of half of the sensor wavelength, so areas with fringes that are very close together indicate greater amounts of deformation in the line-of-sight direction from the sensor.
 
-The wrapped interferogram image is generated from the interferogram phase prior to unwrapping.
+The wrapped interferogram image is generated from the interferogram phase prior to unwrapping. The PNG and KMZ files are tagged with _color_phase, and are 2048 pixels wide. The optional GeoTIFF is tagged with _wrapped_phase.tif
 
-The wrapped interferogram files are tagged with _color_phase, and PNG files are generated in two different resolutions. The file _color_phase.png is a small browse image (1024 pixels wide), and _color_phase_large.png is of higher resolution (2048 pixels wide). The KMZ file is 2048 pixels wide.
+*The GeoTIFF version of the wrapped interferogram is optional. Select the "Include Wrapped Phase" option in the On Demand HyP3 Processing Options to include it in the product package.*
 
 ----------------
 ## 2. Unwrapped Interferogram


### PR DESCRIPTION
Updated README content is taken from https://github.com/ASFHyP3/hyp3-metadata-templates/pull/72

My impression Is "Include Wrapped Phase" is the best user-facing label for this option, but different versions of the README also refer to it as the "Wrapped Interferogram" or simply the "Wrapped GeoTIFF".  I'm open to alternatives if anyone has strong opinions.