### PR TITLE
set OGR_ENABLE_PARTIAL_REPROJECTION=TRUE in create_water_mask

### DIFF
--- a/hyp3_gamma/water_mask.py
+++ b/hyp3_gamma/water_mask.py
@@ -1,6 +1,8 @@
 """Create and apply a water body mask"""
 from osgeo import gdal
 
+from hyp3_gamma.util import GDALConfigManager
+
 gdal.UseExceptions()
 
 
@@ -24,6 +26,7 @@ def create_water_mask(input_tif: str, output_tif: str):
     dst_ds.SetGeoTransform(src_ds.GetGeoTransform())
     dst_ds.SetProjection(src_ds.GetProjection())
     dst_ds.SetMetadataItem('AREA_OR_POINT', src_ds.GetMetadataItem('AREA_OR_POINT'))
-    gdal.Rasterize(dst_ds, mask_location, burnValues=[1])
+    with GDALConfigManager(OGR_ENABLE_PARTIAL_REPROJECTION='TRUE'):
+        gdal.Rasterize(dst_ds, mask_location, burnValues=[1])
 
     del src_ds, dst_ds


### PR DESCRIPTION
eliminates RuntimeError exception when running with gdal=2.2.3 (likely fixed in gdal>=2.3)

```
>>> from hyp3_gamma.water_mask import create_water_mask
>>> create_water_mask('S1BB_20200613T003027_20200625T003028_VVP012_INT80_G_ueF_F13E_unw_phase.tif', 'mask.tif')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/hyp3_gamma/water_mask.py", line 27, in create_water_mask
    gdal.Rasterize(dst_ds, mask_location, burnValues=[1])
  File "/usr/local/lib/python3.6/dist-packages/osgeo/gdal.py", line 1092, in Rasterize
    return wrapper_GDALRasterizeDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
  File "/usr/local/lib/python3.6/dist-packages/osgeo/gdal.py", line 3254, in wrapper_GDALRasterizeDestDS
    return _gdal.wrapper_GDALRasterizeDestDS(*args)
RuntimeError: Full reprojection failed, but partial is possible if you define OGR_ENABLE_PARTIAL_REPROJECTION configuration option to TRUE
```