### PR TITLE
remove pandas==0.23 install from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY GAMMA_SOFTWARE-20191203 /usr/local/GAMMA_SOFTWARE-20191203/
 
 RUN export CPLUS_INCLUDE_PATH=/usr/include/gdal && \
     export C_INCLUDE_PATH=/usr/include/gdal && \
-    python3 -m pip install --no-cache-dir GDAL==2.2.3 pandas==0.23
+    python3 -m pip install --no-cache-dir GDAL==2.2.3
 
 COPY . /hyp3-gamma/
 RUN  python3 -m pip install --no-cache-dir /hyp3-gamma \


### PR DESCRIPTION
Now that geopandas is a `hyp3_gamma` requirement, `pandas==0.23` is installed, but then immediately uninstalled and upgraded to `1.1.5` on line 41 when installing `hyp3_gamma`:
```
#11 21.94   Attempting uninstall: pandas
#11 21.94     Found existing installation: pandas 0.23.0
#11 22.19     Uninstalling pandas-0.23.0:
#11 22.21       Successfully uninstalled pandas-0.23.0
#11 30.70 Successfully installed MarkupSafe-2.0.1 attrs-21.2.0 boto3-1.18.3 botocore-1.21.3 certifi-2021.5.30 charset-normalizer-2.0.3 click-8.0.1 click-plugins-1.1.1 cligj-0.7.2 fiona-1.8.20 geopandas-0.9.0 hyp3-gamma-4.6.2.dev44+g10cff75 hyp3-metadata-1.2.4 hyp3lib-1.6.8 idna-3.2 imageio-2.9.0 importlib-metadata-4.6.1 jinja2-3.0.1 jmespath-0.10.0 lxml-4.6.3 munch-2.5.0 numpy-1.19.5 pandas-1.1.5 patsy-0.5.1 pillow-8.3.1 pyproj-3.0.1 pyshp-2.1.3 python-dateutil-2.8.2 requests-2.26.0 s3transfer-0.5.0 scipy-1.5.4 shapely-1.7.1 statsmodels-0.12.2 typing-extensions-3.10.0.0 urllib3-1.26.6 zipp-3.5.0
```