### PR TITLE
split granule extent on antimeridian before subsetting global shapefile

### DIFF
--- a/hyp3_gamma/water_mask.py
+++ b/hyp3_gamma/water_mask.py
@@ -1,6 +1,6 @@
 """Create and apply a water body mask"""
 import json
-from subprocess import PIPE, run
+import subprocess
 from tempfile import NamedTemporaryFile
 
 import geopandas
@@ -10,8 +10,9 @@ gdal.UseExceptions()
 
 
 def split_geometry_on_antimeridian(geometry: dict):
+    geometry_as_bytes = json.dumps(geometry).encode()
     cmd = ['ogr2ogr', '-wrapdateline', '-datelineoffset', '20', '-f', 'GeoJSON', '/vsistdout', '/vsistdin/']
-    geojson_str = run(cmd, input=json.dumps(geometry).encode(), stdout=PIPE, check=True).stdout
+    geojson_str = subprocess.run(cmd, input=geometry_as_bytes, stdout=subprocess.PIPE, check=True).stdout
     return json.loads(geojson_str)['features'][0]['geometry']
 
 

--- a/hyp3_gamma/water_mask.py
+++ b/hyp3_gamma/water_mask.py
@@ -11,7 +11,7 @@ gdal.UseExceptions()
 
 def split_geometry_on_antimeridian(geometry: dict):
     geometry_as_bytes = json.dumps(geometry).encode()
-    cmd = ['ogr2ogr', '-wrapdateline', '-datelineoffset', '20', '-f', 'GeoJSON', '/vsistdout', '/vsistdin/']
+    cmd = ['ogr2ogr', '-wrapdateline', '-datelineoffset', '20', '-f', 'GeoJSON', '/vsistdout/', '/vsistdin/']
     geojson_str = subprocess.run(cmd, input=geometry_as_bytes, stdout=subprocess.PIPE, check=True).stdout
     return json.loads(geojson_str)['features'][0]['geometry']
 

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -15,7 +15,7 @@ def test_get_geometry_from_kml(test_data_dir):
         'type': 'Polygon',
         'coordinates': [[
             [-154.0, 71.0],
-            [- 147.0, 71.0],
+            [-147.0, 71.0],
             [-146.0, 70.0],
             [-153.0, 69.0],
             [-154.0, 71.0],

--- a/tests/test_water_mask.py
+++ b/tests/test_water_mask.py
@@ -35,7 +35,7 @@ def test_split_geometry_on_antimeridian():
                 [-180.0, 55.0],
                 [-170.0, 55.0],
             ]],
-        ]
+        ],
     }
 
     geometry = {

--- a/tests/test_water_mask.py
+++ b/tests/test_water_mask.py
@@ -9,52 +9,44 @@ gdal.UseExceptions()
 def test_split_geometry_on_antimeridian():
     geometry = {
         "type": "Polygon",
-        "coordinates":
-            [
-                [
-                    [170, 50],
-                    [175, 55],
-                    [-170, 55],
-                    [-175, 50],
-                    [170, 50]]
-            ]
+        "coordinates": [[
+            [170, 50],
+            [175, 55],
+            [-170, 55],
+            [-175, 50],
+            [170, 50],
+        ]],
     }
     result = water_mask.split_geometry_on_antimeridian(geometry)
     assert result == {
         'type': 'MultiPolygon',
         'coordinates': [
-            [
-                [
-                    [175.0, 55.0],
-                    [180.0, 55.0],
-                    [180.0, 50.0],
-                    [170.0, 50.0],
-                    [175.0, 55.0]
-                ]
-            ],
-            [
-                [
-                    [-170.0, 55.0],
-                    [-175.0, 50.0],
-                    [-180.0, 50.0],
-                    [-180.0, 55.0],
-                    [-170.0, 55.0]
-                ]
-            ]
+            [[
+                [175.0, 55.0],
+                [180.0, 55.0],
+                [180.0, 50.0],
+                [170.0, 50.0],
+                [175.0, 55.0],
+            ]],
+            [[
+                [-170.0, 55.0],
+                [-175.0, 50.0],
+                [-180.0, 50.0],
+                [-180.0, 55.0],
+                [-170.0, 55.0],
+            ]],
         ]
     }
 
     geometry = {
         "type": "Polygon",
-        "coordinates":
-            [
-                [
-                    [150, 50],
-                    [155, 55],
-                    [-150, 55],
-                    [-155, 50],
-                    [150, 50]]
-            ]
+        "coordinates": [[
+            [150, 50],
+            [155, 55],
+            [-150, 55],
+            [-155, 50],
+            [150, 50],
+        ]],
     }
     result = water_mask.split_geometry_on_antimeridian(geometry)
     assert result == geometry

--- a/tests/test_water_mask.py
+++ b/tests/test_water_mask.py
@@ -8,8 +8,8 @@ gdal.UseExceptions()
 
 def test_split_geometry_on_antimeridian():
     geometry = {
-        "type": "Polygon",
-        "coordinates": [[
+        'type': 'Polygon',
+        'coordinates': [[
             [170, 50],
             [175, 55],
             [-170, 55],
@@ -39,8 +39,8 @@ def test_split_geometry_on_antimeridian():
     }
 
     geometry = {
-        "type": "Polygon",
-        "coordinates": [[
+        'type': 'Polygon',
+        'coordinates': [[
             [150, 50],
             [155, 55],
             [-150, 55],

--- a/tests/test_water_mask.py
+++ b/tests/test_water_mask.py
@@ -6,6 +6,60 @@ from hyp3_gamma import water_mask
 gdal.UseExceptions()
 
 
+def test_split_geometry_on_antimeridian():
+    geometry = {
+        "type": "Polygon",
+        "coordinates":
+            [
+                [
+                    [170, 50],
+                    [175, 55],
+                    [-170, 55],
+                    [-175, 50],
+                    [170, 50]]
+            ]
+    }
+    result = water_mask.split_geometry_on_antimeridian(geometry)
+    assert result == {
+        'type': 'MultiPolygon',
+        'coordinates': [
+            [
+                [
+                    [175.0, 55.0],
+                    [180.0, 55.0],
+                    [180.0, 50.0],
+                    [170.0, 50.0],
+                    [175.0, 55.0]
+                ]
+            ],
+            [
+                [
+                    [-170.0, 55.0],
+                    [-175.0, 50.0],
+                    [-180.0, 50.0],
+                    [-180.0, 55.0],
+                    [-170.0, 55.0]
+                ]
+            ]
+        ]
+    }
+
+    geometry = {
+        "type": "Polygon",
+        "coordinates":
+            [
+                [
+                    [150, 50],
+                    [155, 55],
+                    [-150, 55],
+                    [-155, 50],
+                    [150, 50]]
+            ]
+    }
+    result = water_mask.split_geometry_on_antimeridian(geometry)
+    assert result == geometry
+
+
 def test_create_water_mask_with_no_water(tmp_path, test_data_dir):
     input_tif = str(test_data_dir / 'test_geotiff.tif')
     output_tif = str(tmp_path / 'water_mask.tif')


### PR DESCRIPTION
~~`split_geometry_on_antimeridian` needs a couple of test cases, simple rectangle crossing the meridian and one not crossing the meridian should suffice.~~ (done)
- `{"type":"Polygon","coordinates":[[[177.8322245,52.4800782],[178.0102838,50.8930535],[-177.2308671,50.9995481],[-177.2391496,52.5927883],[177.8322245,52.4800782]]]}` is the polygon of the meridian granule I was using for local testing, a lower-precision version of that should work

Partially duplicates `hyp3_gamma.dem.get_geometry_from_kml`, I'm open to any suggestions to consolidate them.

Also open to alternatives to `ogr2ogr` to do the splitting itself.