### PR TITLE
wrap unw_phase.png at 12*pi

### DIFF
--- a/hyp3_gamma/insar/unwrapping_geocoding.py
+++ b/hyp3_gamma/insar/unwrapping_geocoding.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-import math
 import os
 from tempfile import TemporaryDirectory
 
@@ -139,7 +138,7 @@ def unwrapping_geocoding(reference, secondary, step="man", rlooks=10, alooks=2, 
         execute(f"mcf {ifgf}.adf {ifgname}.adf.cc {ifgname}.adf.cc_mask.bmp {ifgname}.adf.unw {width} {trimode} 0 0"
                 f" - - {npatr} {npata}", uselogging=True)
 
-    execute(f"rasdt_pwr {ifgname}.adf.unw {mmli} {width} - - - - - {12 * math.pi} 1 rmg.cm {ifgname}.adf.unw.ras",
+    execute(f"rasdt_pwr {ifgname}.adf.unw {mmli} {width} - - - - - {12 * np.pi} 1 rmg.cm {ifgname}.adf.unw.ras",
             uselogging=True)
 
     execute(f"dispmap {ifgname}.adf.unw DEM/HGT_SAR_{rlooks}_{alooks} {mmli}.par"

--- a/hyp3_gamma/insar/unwrapping_geocoding.py
+++ b/hyp3_gamma/insar/unwrapping_geocoding.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import math
 import os
 from tempfile import TemporaryDirectory
 
@@ -138,7 +139,8 @@ def unwrapping_geocoding(reference, secondary, step="man", rlooks=10, alooks=2, 
         execute(f"mcf {ifgf}.adf {ifgname}.adf.cc {ifgname}.adf.cc_mask.bmp {ifgname}.adf.unw {width} {trimode} 0 0"
                 f" - - {npatr} {npata}", uselogging=True)
 
-    execute(f"rasdt_pwr {ifgname}.adf.unw {mmli} {width} - - - - - - 1 rmg.cm {ifgname}.adf.unw.ras", uselogging=True)
+    execute(f"rasdt_pwr {ifgname}.adf.unw {mmli} {width} - - - - - {12 * math.pi} 1 rmg.cm {ifgname}.adf.unw.ras",
+            uselogging=True)
 
     execute(f"dispmap {ifgname}.adf.unw DEM/HGT_SAR_{rlooks}_{alooks} {mmli}.par"
             f" - {ifgname}.vert.disp 1", uselogging=True)


### PR DESCRIPTION
The `rasdt_pwr` call to create the `unw_phase.png` browse image was incorrectly implemented in the [initial gamma upgrade PR](https://github.com/ASFHyP3/hyp3-gamma/pull/303):
```
< rasrmg {ifgname}.adf.unw {mmli} {width} 1 1 0 1 1 0.33333 1.0 .35 0.0 - {ifgname}.adf.unw.ras
> rasdt_pwr {ifgname}.adf.unw {mmli} {width} - - - - - - 1 rmg.cm {ifgname}.adf.unw.ras
```
The fringes were incorrectly wrapped to mod `1.0` instead of mod `12*pi`. This fixes the wrapping. The fixed fringes start at a different value compared with production, but I'm comfortable leaving that unaddressed.

Production:
![prod](https://user-images.githubusercontent.com/17994518/131268201-d79609b5-5eb5-45dd-a680-521eeb7320fc.png)

Test:
![test](https://user-images.githubusercontent.com/17994518/131268205-4178cea2-8e70-4633-9181-11929556089b.png)

Fixed:
![fixed](https://user-images.githubusercontent.com/17994518/131268262-14031336-ac43-4053-b356-4cc03d103ff7.png)

