### PR TITLE
upgrade pip and pin numpy version to match system ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN apt update \
 COPY GAMMA_SOFTWARE-20210701 /usr/local/GAMMA_SOFTWARE-20210701/
 
 COPY . /hyp3-gamma/
-RUN python3 -m pip install --no-cache-dir /hyp3-gamma \
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install --no-cache-dir /hyp3-gamma \
     && rm -rf /hyp3-gamma
 
 ARG CONDA_GID=1000

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,6 @@ dependencies:
   - importlib_metadata
   - jinja2
   - lxml
-  - numpy
+  - numpy>=1.17,<1.18
   - pillow
   - python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'importlib_metadata',
         'jinja2',
         'lxml',
-        'numpy',
+        'numpy>=1.17,<1.18',
         'pillow',
         'python-dateutil',
     ],


### PR DESCRIPTION
The apt install puts v1.17.4 in the container. With this approach, the subsequent pip install doesn't change numpy and correctly brings in pandas 1.3.5.

Numpy 1.17.4 isn't available via conda-forge, but 1.17.5 is, hence not pinning either setup.py or environment.yml to a specific patch version.