### PR TITLE
Fix changelog syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 5.1.3
+## [5.1.3]
 
-### Security
+### Added
 
 * It is now possible to inject Earthdata username and password using environment variables: `EARTHDATA_USERNAME`
   and `EARTHDATA_PASSWORD`.


### PR DESCRIPTION
Square brackets are required around the version number for our actions to work, as per the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) spec

Also, `Security` section is for vulnerabilities, where allowing EDL username/password via env variables is a user feature we added. 