### PR TITLE
Rework how we bring in the asf-tools conda env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+## ASF TOOLS
+ARG ASF_TOOLS_IMAGE=845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+ARG ASF_TOOLS_TAG=5.1.2
+
+FROM ${ASF_TOOLS_IMAGE}:${ASF_TOOLS_TAG} as asf-tools
+
 FROM ubuntu:20.04
 
 # For opencontainers label definitions, see:
@@ -69,12 +75,8 @@ ENV HDF5_DISABLE_VERSION_CHECK=1
 
 WORKDIR /home/conda/
 
-## ASF TOOLS
-ARG ASF_TOOLS_IMAGE=845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
-ARG ASF_TOOLS_TAG=5.1.2
-
-COPY --from=${ASF_TOOLS_IMAGE}:${ASF_TOOLS_TAG} --chown=${CONDA_GID}:${CONDA_UID} /home/conda/mambaforge /home/conda/mambaforge
-COPY --from=${ASF_TOOLS_IMAGE}:${ASF_TOOLS_TAG} --chown=${CONDA_GID}:${CONDA_UID} /home/conda/.profile /home/conda/.condarc /home/conda/
+COPY --from=asf-tools --chown=${CONDA_GID}:${CONDA_UID} /home/conda/mambaforge /home/conda/mambaforge
+COPY --from=asf-tools --chown=${CONDA_GID}:${CONDA_UID} /home/conda/.profile /home/conda/.condarc /home/conda/
 
 ENV PATH=$PATH:/home/conda/mambaforge/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,9 +70,13 @@ ENV HDF5_DISABLE_VERSION_CHECK=1
 WORKDIR /home/conda/
 
 ## ASF TOOLS
-COPY --from=845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma:5.1.2 /home/conda/mambaforge /home/conda/mambaforge
-COPY --from=845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma:5.1.2 /home/conda/.profile /home/conda/.profile
-COPY --from=845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma:5.1.2 /home/conda/.condarc /home/conda/.condarc
+ARG ASF_TOOLS_IMAGE=845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+ARG ASF_TOOLS_TAG=5.1.2
+
+COPY --from=${ASF_TOOLS_IMAGE}:${ASF_TOOLS_TAG} --chown=${CONDA_GID}:${CONDA_UID} /home/conda/mambaforge /home/conda/mambaforge
+COPY --from=${ASF_TOOLS_IMAGE}:${ASF_TOOLS_TAG} --chown=${CONDA_GID}:${CONDA_UID} /home/conda/.profile /home/conda/.condarc /home/conda/
+
+ENV PATH=$PATH:/home/conda/mambaforge/bin
 
 ENTRYPOINT ["/usr/local/bin/hyp3_gamma"]
 CMD ["-h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,24 +70,9 @@ ENV HDF5_DISABLE_VERSION_CHECK=1
 WORKDIR /home/conda/
 
 ## ASF TOOLS
-RUN wget --progress=dot:mega https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh \
-    && bash Mambaforge-Linux-x86_64.sh -b \
-    && rm -f Mambaforge-Linux-x86_64.sh \
-    && echo PATH="/home/conda/mambaforge/bin":$PATH >> .profile \
-    && echo ". /home/conda/mambaforge/etc/profile.d/conda.sh" >> .profile
-
-ENV PATH=$PATH:/home/conda/mambaforge/bin
-
-RUN conda --version \
-    && conda config --set auto_activate_base false
-
-# FIXME: dev branch and cached stale clone
-RUN git clone https://github.com/ASFHyP3/asf-tools.git \
-    && mamba env create -f asf-tools/environment.yml \
-    && mamba clean -afy
-
-RUN conda run -n asf-tools python -m pip install --no-cache-dir ./asf-tools \
-    && rm -rf ./asf-tools
+COPY --from=845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma:5.1.2 /home/conda/mambaforge /home/conda/mambaforge
+COPY --from=845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma:5.1.2 /home/conda/.profile /home/conda/.profile
+COPY --from=845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma:5.1.2 /home/conda/.condarc /home/conda/.condarc
 
 ENTRYPOINT ["/usr/local/bin/hyp3_gamma"]
 CMD ["-h"]


### PR DESCRIPTION
This is an *extremely* short term fix to pin the asf-tools environment used for water mapping back to the last known working environment and also keep `hpy3-gamma` up to date. 

It's directly copying the asf-tools env, so there's no dependency updates or changes and it should function *exactly* like in v5.1.2

This also paves the way for a medium term, or possibly long term, way to manage and develop these environments separately:
* In ASFHyP3/asf-tools#94 we're developing an asf-tools container which can become the source of truth for the asf-tools environment here and this container would always copy in the `latest` asf-tools env out of that container
  * asf-tools development can be managed entirely in the asf-tools space
  * hyp3-gamma develop can continue without worrying about the water mapping environment 
  