### PR TITLE
Release updated InSAR code with new validity thresholds and reference point calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [5.2.0]
 
 ### Changed
-* Validity mask is determined by cc 0.1 and pwr 0.0. reference point is determined with cc only.
-  Use cc to find the pixels with max value. Use a 9-pixel window around the pixels with the highest
-  coherence to determine which one has the highest neighborhood coherence value
+* The amplitude threshold used for the InSAR phase unwrapping validity mask was changed from 0.2 to 0.0 (in power scale). The coherence threshold remains at 0.1, so the validity mask is now calculated based only on coherence values.
+* The InSAR phase unwrapping reference point is now determined using a neighborhood coherence value. The pixels with the highest coherence are examined using a 9-pixel window to find the pixel with the highest neighborhood coherence value, which is then used as the reference point for phase unwrapping.
 
 ## [5.1.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.0]
+
+### Changed
+* Validity mask is determined by cc 0.1 and pwr 0.0. reference point is determined with cc only.
+  Use cc to find the pixels with max value. Use a 9-pixel window around the pixels with the highest
+  coherence to determine which one has the highest neighborhood coherence value
 
 ## [5.1.8]
 

--- a/tests/insar/test_unwrapping_geocoding.py
+++ b/tests/insar/test_unwrapping_geocoding.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+from hyp3_gamma.insar.unwrapping_geocoding import get_neighbors, ref_point_with_max_cc
+
+
+def test_get_neighbors():
+    array = np.arange(0, 5 * 5)
+    array.shape = (5, 5)
+
+    assert np.array_equal(get_neighbors(array, 0, 0), np.array([[0, 1], [5, 6]]))
+    assert np.array_equal(get_neighbors(array, 0, 4), np.array([[3, 4], [8, 9]]))
+    assert np.array_equal(get_neighbors(array, 4, 0), np.array([[15, 16], [20, 21]]))
+    assert np.array_equal(get_neighbors(array, 4, 4), np.array([[18, 19], [23, 24]]))
+
+    assert np.array_equal(get_neighbors(array, 0, 2), np.array([[1, 2, 3], [6, 7, 8]]))
+    assert np.array_equal(get_neighbors(array, 2, 0), np.array([[5, 6], [10, 11], [15, 16]]))
+    assert np.array_equal(get_neighbors(array, 2, 4), np.array([[8, 9], [13, 14], [18, 19]]))
+    assert np.array_equal(get_neighbors(array, 4, 2), np.array([[16, 17, 18], [21, 22, 23]]))
+
+    assert np.array_equal(get_neighbors(array, 2, 2), np.array([[6, 7, 8], [11, 12, 13], [16, 17, 18]]))
+
+
+def test_get_neighbors_bigger_n():
+    array = np.arange(0, 5 * 5)
+    array.shape = (5, 5)
+
+    assert np.array_equal(get_neighbors(array, 1, 1, n=2),
+                          np.array([[0, 1, 2, 3], [5, 6, 7, 8], [10, 11, 12, 13], [15, 16, 17, 18]]))
+    assert np.array_equal(get_neighbors(array, 1, 1, n=3), array)
+    assert np.array_equal(get_neighbors(array, 1, 1, n=4), array)
+
+
+def test_ref_point_with_max_cc():
+    array = np.array([
+        [0.0, 0.0],
+        [0.0, 0.0],
+    ])
+    assert ref_point_with_max_cc(array) == (0, 0)
+
+    array = np.array([
+        [0.0, 0.00001],
+        [0.0, 0.0],
+    ])
+    assert ref_point_with_max_cc(array) == (0, 1)
+
+    array = np.array([
+        [0.0, 0.00001],
+        [1.0, 0.0],
+    ])
+    assert ref_point_with_max_cc(array) == (0, 1)
+
+    array = np.array([
+        [0.5, 0.2, 0.0],
+        [0.2, 0.2, 0.201],
+        [0.0, 0.2, 0.5],
+    ])
+    assert ref_point_with_max_cc(array) == (2, 2)
+
+    array = np.array([
+        [0.5, 0.201, 0.0],
+        [0.2, 0.2, 0.2],
+        [0.0, 0.2, 0.5],
+    ])
+    assert ref_point_with_max_cc(array) == (0, 0)


### PR DESCRIPTION
We have updated the InSAR code to set the amplitude threshold for the validity mask to 0.0. In addition, the reference point is now selected based on the neighborhood values, ensuring that the high coherence pixel is amidst other high coherence pixels.