### PR TITLE
fix the error arguments azlin and rpix in the sarpix_coord command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.1]
+
+### Changed
+* Output the reference point in SAR space in the meta text file. The reference point indexes start form 0.
 ## [5.2.0]
 
 ### Changed

--- a/hyp3_gamma/insar/unwrapping_geocoding.py
+++ b/hyp3_gamma/insar/unwrapping_geocoding.py
@@ -259,13 +259,13 @@ def unwrapping_geocoding(reference, secondary, step="man", rlooks=10, alooks=2, 
         cc_ref = apply_mask(f'{ifgname}.cc', int(mlines), int(mwidth), 'water_mask_sar.bmp')
 
     data_cc = read_bin(cc_ref, int(mlines), int(mwidth))
-    ref_azlin_offset, ref_rpix_offset = ref_point_with_max_cc(data_cc)
+    ref_azlin, ref_rpix = ref_point_with_max_cc(data_cc)
 
     mcf_log = execute(f"mcf {ifgf}.adf {ifgname}.adf.cc {out_file} {ifgname}.adf.unw {width} {trimode} 0 0"
-                      f" - - {npatr} {npata} - {ref_rpix_offset} {ref_azlin_offset} 1", uselogging=True)
+                      f" - - {npatr} {npata} - {ref_rpix} {ref_azlin} 1", uselogging=True)
 
     ref_point_info = get_ref_point_info(mcf_log)
-    coords = get_coords(f"{mmli}.par", ref_azlin=ref_azlin_offset + 1, ref_rpix=ref_rpix_offset + 1, in_dem_par=dempar)
+    coords = get_coords(f"{mmli}.par", ref_azlin=ref_azlin, ref_rpix=ref_rpix, in_dem_par=dempar)
 
     execute(f"rasdt_pwr {ifgname}.adf.unw {mmli} {width} - - - - - {6 * np.pi} 1 rmg.cm {ifgname}.adf.unw.ras",
             uselogging=True)


### PR DESCRIPTION
<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/hyp3-gamma/compare/main...develop?template=release.md
 
If this PR does not include changes that should be reflected in CHANGELOG.md,
please indicate so by affixing the `bumpless` label to this PR.

NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->
This PR solves the issue about the reference point indexes. In previous version, we get fooled by the output of the mcf command. It always reports the reference point as the azlin+1, rpix+1, where azlin and rpix are the arguments of the mcf, and are reference point indexes starting from 0. After testing, we found that the sarpix_coord command accepts the reference point (azlin, rpix) which is based on indexes starting from 0. So we correct the previous code, and output the reference point  indexes stating from 0 in the meta text. We need explain the reference point in the InSAR Product Guide and/or README file.    
