### PR TITLE
Use a strict watermask for AVO

### DIFF
--- a/hyp3_gamma/water_mask.py
+++ b/hyp3_gamma/water_mask.py
@@ -29,7 +29,8 @@ def create_water_mask(input_tif: str, output_tif: str):
         input_tif: Path for the input GeoTIFF
         output_tif: Path for the output GeoTIFF
     """
-    mask_location = '/vsicurl/https://asf-dem-west.s3.amazonaws.com/WATER_MASK/GSHHG/GSHHS_f_L1.shp'
+    # mask_location = '/vsicurl/https://asf-dem-west.s3.amazonaws.com/WATER_MASK/GSHHG/GSHHS_f_L1.shp'
+    mask_location = '/vsicurl/https://asf-dem-west.s3.amazonaws.com/WATER_MASK/GSHHG/GSHHS_shp/f/GSHHS_f_L1.shp'
 
     src_ds = gdal.Open(input_tif)
 


### PR DESCRIPTION
AVO processing identified some issues with InSAR GAMMA products where an un-physical subsidence was observed due to GAMMA keying in on a "signal" over the water. Our current water mask is buffered such that these narrow water bodies aren't masked out.

This switches to a a much stricter water mask that is not buffered away from the cost line. 

HOWEVER, this mask does not include Antarctica or the inland great lakes, so is likely not suitable for general HyP3. 

This PR is only to provide a docker image we can use for the AVO deployment, and should not be merged in favor of a latter PR that creates a more suitable strict water mask (and possibly an option to select which to use). 