### PR TITLE
fix typo in call to flood_map

### DIFF
--- a/hyp3_gamma/__main__.py
+++ b/hyp3_gamma/__main__.py
@@ -226,7 +226,7 @@ def water_map():
         execute(f'conda run -n  asf-tools flood_map {product_name}/{product_name}_FM.tif '
                 f'{product_name}/{product_name}_VV.tif {product_name}/{product_name}_WM.tif '
                 f'{product_name}/{product_name}_WM_HAND.tif --estimator {args.estimator} '
-                f'--water-level-sigma {args.water_level_sigma} --known-water-threshold {args.known_water_threshold}'
+                f'--water-level-sigma {args.water_level_sigma} --known-water-threshold {args.known_water_threshold} '
                 f'--iterative-bounds {args.iterative_min} {args.iterative_max}',
                 uselogging=True)
 


### PR DESCRIPTION
fixes water_map jobs failing with `flood_map: error: argument --known-water-threshold: invalid float value: '30.0--iterative-bounds'`