### PR TITLE
upgrade to gamma 20220630

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -59,8 +59,8 @@ jobs:
 
       - name: Fetch GAMMA
         run: |
-          aws s3 cp s3://hyp3-software/GAMMA_SOFTWARE-20210701_MSP_ISP_DIFF_LAT.linux64_ubuntu2004.tar.gz .
-          tar -zxvf GAMMA_SOFTWARE-20210701_MSP_ISP_DIFF_LAT.linux64_ubuntu2004.tar.gz
+          aws s3 cp s3://hyp3-software/GAMMA_SOFTWARE-20220630_MSP_ISP_DIFF_LAT.linux64_ubuntu2004.tar.gz .
+          tar -zxvf GAMMA_SOFTWARE-20220630_MSP_ISP_DIFF_LAT.linux64_ubuntu2004.tar.gz
 
       - name: Build, tag, and push image to Amazon ECR
         uses: docker/build-push-action@v2

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -22,13 +22,13 @@ jobs:
     with:
       local_package_name: hyp3_gamma
       conda_env_name: hyp3-gamma
-      python_version: '3.8'
+      python_version: '3.10'
 
   call-version-info-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@main
     with:
       conda_env_name: hyp3-gamma
-      python_version: '3.8'
+      python_version: '3.10'
 
   dockerize:
     needs: call-version-info-workflow
@@ -59,8 +59,8 @@ jobs:
 
       - name: Fetch GAMMA
         run: |
-          aws s3 cp s3://hyp3-software/GAMMA_SOFTWARE-20220630_MSP_ISP_DIFF_LAT.linux64_ubuntu2004.tar.gz .
-          tar -zxvf GAMMA_SOFTWARE-20220630_MSP_ISP_DIFF_LAT.linux64_ubuntu2004.tar.gz
+          aws s3 cp s3://hyp3-software/GAMMA_SOFTWARE-20220630_MSP_ISP_DIFF_LAT.linux64_ubuntu2204.tar.gz .
+          tar -zxvf GAMMA_SOFTWARE-20220630_MSP_ISP_DIFF_LAT.linux64_ubuntu2204.tar.gz
 
       - name: Build, tag, and push image to Amazon ECR
         uses: docker/build-push-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [5.5.0]
 
 ### Changed
-- Upgraded to [GAMMA software](https://www.gamma-rs.ch/software) `20220630` from `20210701`
+* Upgraded to the latest available [GAMMA software](https://www.gamma-rs.ch/software) version and related dependencies
+  * GAMMA software `20220630` from `20210701`
+  * Ubuntu 22.04 from 20.04
+  * Python 3.10.4 from 3.8.10
+  * numpy 1.21.5 from 1.17.4
+  * GDAL 3.4.1 from 3.0.4
 
 ## [5.4.4]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [5.5.0]
+
+### Changed
+- Upgraded to [GAMMA software](https://www.gamma-rs.ch/software) `20220630` from `20210701`
+
 ## [5.4.4]
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt update \
          gdal-bin libgdal-dev \
          libhdf5-dev libhdf5-103 \
          libblas-dev libblas3 liblapack-dev liblapack3 liblapack-doc \
-         python-is-python3 python3-numpy python3-matplotlib python3-scipy python3-shapely python3-packaging\
+         python-is-python3 python3-numpy python3-matplotlib python3-scipy python3-shapely python3-packaging \
          # GAMMA scripts require csh/tcsh
          tcsh \
          # Additional installs

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt update \
          gdal-bin libgdal-dev \
          libhdf5-dev libhdf5-103 \
          libblas-dev libblas3 liblapack-dev liblapack3 liblapack-doc \
-         python-is-python3 python3-numpy python3-matplotlib python3-scipy python3-shapely \
+         python-is-python3 python3-numpy python3-matplotlib python3-scipy python3-shapely python3-packaging\
          # GAMMA scripts require csh/tcsh
          tcsh \
          # Additional installs
@@ -42,7 +42,7 @@ RUN apt update \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
-COPY GAMMA_SOFTWARE-20210701 /usr/local/GAMMA_SOFTWARE-20210701/
+COPY GAMMA_SOFTWARE-20220630 /usr/local/GAMMA_SOFTWARE-20220630/
 
 COPY . /hyp3-gamma/
 RUN python3 -m pip install --upgrade pip \
@@ -60,7 +60,7 @@ SHELL ["/bin/bash", "-l", "-c"]
 ENV PYTHONDONTWRITEBYTECODE=true
 
 # GAMMA environment variables per section 1 of the Linux installation guide
-ENV GAMMA_VERSION=20210701
+ENV GAMMA_VERSION=20220630
 ENV GAMMA_HOME=/usr/local/GAMMA_SOFTWARE-${GAMMA_VERSION}
 ENV MSP_HOME=$GAMMA_HOME/MSP
 ENV ISP_HOME=$GAMMA_HOME/ISP

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ASF_TOOLS_TAG=0.4.2
 
 FROM ${ASF_TOOLS_IMAGE}:${ASF_TOOLS_TAG} as asf-tools
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # For opencontainers label definitions, see:
 #    https://github.com/opencontainers/image-spec/blob/master/annotations.md

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.8
+  - python=3.10
   - pip
   # For packaging, and testing
   - flake8
@@ -23,6 +23,6 @@ dependencies:
   - importlib_metadata
   - jinja2
   - lxml
-  - numpy>=1.17,<1.18
+  - numpy
   - pillow
   - python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.10',
     ],
 
-    python_requires='~=3.8',
+    python_requires='~=3.10',
 
     install_requires=[
         'gdal',
@@ -39,7 +39,7 @@ setup(
         'importlib_metadata',
         'jinja2',
         'lxml',
-        'numpy>=1.17,<1.18',
+        'numpy',
         'pillow',
         'python-dateutil',
     ],


### PR DESCRIPTION
Only significant change between the 202206030 linux installation guide and the one from 20210701 is the addition of `python3-packaging`. The 20220630 installation guides for ubuntu 20.04 and 22.04 are byte-for-byte identical.

I've run rtc for `S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8` and insar for `S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8+S1A_IW_SLC__1SSV_20150504T120217_20150504T120229_005771_00769E_EF9A` on my local machine with all default options. They both run to completion and produce output that looks consistent to the naked eye in a GIS.

Will need to run a full test suite to exercise all the parameter options and code paths.