### PR TITLE
set OGR_GEOJSON_MAX_OBJ_SIZE in create_water_map

### DIFF
--- a/hyp3_gamma/water_mask.py
+++ b/hyp3_gamma/water_mask.py
@@ -6,6 +6,8 @@ from tempfile import NamedTemporaryFile
 import geopandas
 from osgeo import gdal
 
+from hyp3_gamma.util import GDALConfigManager
+
 gdal.UseExceptions()
 
 
@@ -44,6 +46,7 @@ def create_water_mask(input_tif: str, output_tif: str):
     mask = geopandas.read_file(mask_location, mask=extent)
     with NamedTemporaryFile() as temp_file:
         mask.to_file(temp_file.name, driver='GeoJSON')
-        gdal.Rasterize(dst_ds, temp_file.name, allTouched=True, burnValues=[1])
+        with GDALConfigManager(OGR_GEOJSON_MAX_OBJ_SIZE='500MB'):
+            gdal.Rasterize(dst_ds, temp_file.name, allTouched=True, burnValues=[1])
 
     del src_ds, dst_ds

--- a/hyp3_gamma/water_mask.py
+++ b/hyp3_gamma/water_mask.py
@@ -1,7 +1,7 @@
 """Create and apply a water body mask"""
 import json
 import subprocess
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
 
 import geopandas
 from osgeo import gdal
@@ -44,9 +44,8 @@ def create_water_mask(input_tif: str, output_tif: str):
     extent = split_geometry_on_antimeridian(extent)
 
     mask = geopandas.read_file(mask_location, mask=extent)
-    with NamedTemporaryFile() as temp_file:
-        mask.to_file(temp_file.name, driver='GeoJSON')
-        with GDALConfigManager(OGR_GEOJSON_MAX_OBJ_SIZE='500MB'):
-            gdal.Rasterize(dst_ds, temp_file.name, allTouched=True, burnValues=[1])
+    with TemporaryDirectory() as temp_file:
+        mask.to_file(temp_file.name, driver='ESRI Shapefile')
+        gdal.Rasterize(dst_ds, temp_file.name, allTouched=True, burnValues=[1])
 
     del src_ds, dst_ds

--- a/hyp3_gamma/water_mask.py
+++ b/hyp3_gamma/water_mask.py
@@ -44,8 +44,8 @@ def create_water_mask(input_tif: str, output_tif: str):
     extent = split_geometry_on_antimeridian(extent)
 
     mask = geopandas.read_file(mask_location, mask=extent)
-    with TemporaryDirectory() as temp_file:
-        mask.to_file(temp_file.name, driver='ESRI Shapefile')
-        gdal.Rasterize(dst_ds, temp_file.name, allTouched=True, burnValues=[1])
+    with TemporaryDirectory() as temp_shapefile:
+        mask.to_file(temp_shapefile, driver='ESRI Shapefile')
+        gdal.Rasterize(dst_ds, temp_shapefile, allTouched=True, burnValues=[1])
 
     del src_ds, dst_ds

--- a/hyp3_gamma/water_mask.py
+++ b/hyp3_gamma/water_mask.py
@@ -6,8 +6,6 @@ from tempfile import TemporaryDirectory
 import geopandas
 from osgeo import gdal
 
-from hyp3_gamma.util import GDALConfigManager
-
 gdal.UseExceptions()
 
 


### PR DESCRIPTION
Here's a crude and quick fix to the `ERROR 1: GeoJSON object too complex, please see the OGR_GEOJSON_MAX_OBJ_SIZE environment option` errors we see when processing these scenes over the Aegean Sea:
- `S1B_IW_SLC__1SDV_20201115T162313_20201115T162340_024278_02E29D_5C54`
- `S1A_IW_SLC__1SDV_20201203T162353_20201203T162420_035524_042744_6D5C`

The `OGR_GEOJSON_MAX_OBJ_SIZE` setting is specific to the GDAL GeoJSON driver, documentation is at https://gdal.org/drivers/vector/geojson.html#configuration-options

We're using GeoJSON for the temp file out of convenience, we might be able to avoid this issue by using any other [GDAL-supported vector format](https://gdal.org/drivers/vector/index.html).

Alternatively, if we stick with GeoJSON, it would be nice to set `OGR_GEOJSON_MAX_OBJ_SIZE` based on the size of the temporary geojson file instead of to an arbitrary big value.

@jacquelynsmale any thoughts on those options? Would you be interested in taking a stab at implementing either? I've only checked that this code still passes the unit tests, I haven't yet verified it fixes the issue for the specific pair in question.