### PR TITLE
set OGR_ENABLE_PARTIAL_REPROJECTION=YES in create_water_map

### DIFF
--- a/hyp3_gamma/water_mask.py
+++ b/hyp3_gamma/water_mask.py
@@ -6,6 +6,8 @@ from tempfile import TemporaryDirectory
 import geopandas
 from osgeo import gdal
 
+from hyp3_gamma.util import GDALConfigManager
+
 gdal.UseExceptions()
 
 
@@ -44,6 +46,7 @@ def create_water_mask(input_tif: str, output_tif: str):
     mask = geopandas.read_file(mask_location, mask=extent)
     with TemporaryDirectory() as temp_shapefile:
         mask.to_file(temp_shapefile, driver='ESRI Shapefile')
-        gdal.Rasterize(dst_ds, temp_shapefile, allTouched=True, burnValues=[1])
+        with GDALConfigManager(OGR_ENABLE_PARTIAL_REPROJECTION='YES'):
+            gdal.Rasterize(dst_ds, temp_shapefile, allTouched=True, burnValues=[1])
 
     del src_ds, dst_ds


### PR DESCRIPTION
Resolves `ERROR 1: Full reprojection failed, but partial is possible if you define OGR_ENABLE_PARTIAL_REPROJECTION configuration option to TRUE` issue in call to gdal.Rasterize that resulted in not all land bodies being successfully recognized in the water mask:
![Screenshot from 2022-09-23 16-37-37](https://user-images.githubusercontent.com/17994518/192072916-60b87f61-b924-47fb-bf4b-a708fd7703ce.png)

Setting this option gives the desired mask for this region:
![Screenshot from 2022-09-23 16-37-46](https://user-images.githubusercontent.com/17994518/192072927-d7323f6d-7f1d-43ed-a98c-d3b0c9f41fe1.png)
