### PR TITLE
Use importlib.metadata instead of depreciated pkg_resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+
+## [5.7.1]
+
+### Changed
+* Upgraded to [`importlib.metadata.entry_points()`](https://docs.python.org/3.10/library/importlib.metadata.html#entry-points)
+  for loading [`console_script` `entry_point`](https://packaging.python.org/en/latest/specifications/entry-points/)
+  functions from the depreciated [`pkg_resources`](https://setuptools.pypa.io/en/latest/pkg_resources.html) package  
+
 ## [5.7.0]
 
 ### Changed

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,6 @@ dependencies:
   - gdal>=3.4,<3.5
   - geopandas
   - hyp3lib>=1.7.0,<2
-  - importlib_metadata
   - jinja2
   - lxml
   - numpy>=1.21,<1.22

--- a/hyp3_gamma/__main__.py
+++ b/hyp3_gamma/__main__.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from importlib.metadata import entry_points
 from pathlib import Path
 from shutil import make_archive
 
@@ -13,7 +14,6 @@ from hyp3lib.execute import execute
 from hyp3lib.fetch import write_credentials_to_netrc_file
 from hyp3lib.image import create_thumbnail
 from hyp3lib.util import string_is_true
-from pkg_resources import load_entry_point
 
 from hyp3_gamma import util
 from hyp3_gamma.insar.ifm_sentinel import insar_sentinel_gamma
@@ -27,10 +27,11 @@ def main():
         help='Select the HyP3 entrypoint version to use'
     )
     args, unknowns = parser.parse_known_args()
+    (process_entry_point,) = entry_points(group='console_scripts', name=args.process)
 
     sys.argv = [args.process, *unknowns]
     sys.exit(
-        load_entry_point('hyp3_gamma', 'console_scripts', args.process)()
+        process_entry_point.load()()
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         'gdal>=3.4,<3.5',
         'geopandas',
         'hyp3lib>=1.7.0,<2',
-        'importlib_metadata',
         'jinja2',
         'lxml',
         'numpy>=1.21,<1.22',


### PR DESCRIPTION
[pkg_resources](https://setuptools.pypa.io/en/latest/pkg_resources.html) provided by setuptools has a depreciation warning in their docs stating:
> :warning: Attention
> 
> Use of pkg_resources is discouraged in favor of [importlib.resources](https://docs.python.org/3/library/importlib.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html), and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Please consider using those libraries instead of pkg_resources.

This updates the entry_point loading method to use [`importlib.metadata.entry_points()`](https://docs.python.org/3.10/library/importlib.metadata.html#entry-points), which is part of the python standard library, for loading the `entry_point` functions. 