### PR TITLE
add ++omp-num-threads parameter to main() entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [5.7.4]
+
+### Added
+- `++omp-num-threads` parameter to the `main()` entrypoint to limit the number of threads used by GAMMA during
+  multiprocessing.
+
 ## [5.7.3]
 
 ### Added

--- a/hyp3_gamma/__main__.py
+++ b/hyp3_gamma/__main__.py
@@ -30,7 +30,7 @@ def main():
     args, unknowns = parser.parse_known_args()
     (process_entry_point,) = entry_points(group='console_scripts', name=args.process)
 
-    if args.thread_limit:
+    if args.omp_num_threads:
         os.environ['OMP_NUM_THREADS'] = str(args.omp_num_threads)
 
     sys.argv = [args.process, *unknowns]

--- a/hyp3_gamma/__main__.py
+++ b/hyp3_gamma/__main__.py
@@ -26,8 +26,12 @@ def main():
         '++process', choices=['rtc', 'insar', 'water_map'], default='rtc',
         help='Select the HyP3 entrypoint version to use'
     )
+    parser.add_argument('++omp-num-threads', type=int, help='The number of OpenMP threads to use for parallel regions')
     args, unknowns = parser.parse_known_args()
     (process_entry_point,) = entry_points(group='console_scripts', name=args.process)
+
+    if args.thread_limit:
+        os.environ['OMP_NUM_THREADS'] = str(args.omp_num_threads)
 
     sys.argv = [args.process, *unknowns]
     sys.exit(


### PR DESCRIPTION
GAMMA programs use OpenMP for parallel processing. The number of threads used range from 3-12+ from program to program. This can lead to severe CPU contention when running multiple GAMMA jobs on the same machine, drastically increasing the run time of those jobs.

This PR adds a command line parameter to the `main()` entrypoint to set the `OMP_NUM_THREADS` environment variable. See https://www.ibm.com/docs/en/zos/2.2.0?topic=suce-environment-variables-openmp

This allows running multiple jobs on the same machine without CPU contention. For example, running two jobs on an 8 core machine would typically result in both jobs trying to use all 8 cores at the same time. Setting `++omp-num-threads=4` for each job would limit the total demand to match the number of available cores and eliminates the performance degradation.