### PR TITLE
drop asf-tools env from container and watermap hyp3 entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [5.8.0]
+
+### Removed
+- Surface water extent mapping processing of RTC products, which is now entirely contained in 
+  [asf-tools](https://github.com/ASFHyP3/asf-tools/) and its associated docker container image. This includes:
+  - `water_map` entrypoint to create a water map product; use
+  - `asf_tools` environment from the hyp3-gamma docker container image
+
 ## [5.7.5]
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,3 @@
-## ASF TOOLS
-ARG ASF_TOOLS_IMAGE='ghcr.io/asfhyp3/asf-tools'
-ARG ASF_TOOLS_TAG=0.4.4
-
-FROM ${ASF_TOOLS_IMAGE}:${ASF_TOOLS_TAG} as asf-tools
-
 FROM ubuntu:22.04
 
 # For opencontainers label definitions, see:
@@ -74,11 +68,6 @@ ENV PYTHONPATH=$GAMMA_HOME:$PYTHONPATH
 ENV HDF5_DISABLE_VERSION_CHECK=1
 
 WORKDIR /home/conda/
-
-COPY --from=asf-tools --chown=${CONDA_GID}:${CONDA_UID} /opt/conda /opt/conda
-COPY --from=asf-tools --chown=${CONDA_GID}:${CONDA_UID} /home/conda/.profile /home/conda/
-
-ENV PATH=$PATH:/opt/conda/bin
 
 ENTRYPOINT ["/usr/local/bin/hyp3_gamma"]
 CMD ["-h"]


### PR DESCRIPTION
Once HyP3 uses asf-tools directly to run the water map and flood depth code, we can drop all that from this container. 

Will need to test that RTC and InSAR jobs still work. 