### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 - Surface water extent mapping processing of RTC products, which is now entirely contained in 
   [asf-tools](https://github.com/ASFHyP3/asf-tools/) and its associated docker container image. This includes:
-  - `water_map` entrypoint to create a water map product; use
+  - `water_map` entrypoint to create a water map product
   - `asf_tools` environment from the hyp3-gamma docker container image
 
 ## [5.7.5]


### PR DESCRIPTION
I'm open to expanding on the details, but "moved to asf-tools" seems sufficient, rather than saying a HyP3 WATER_MAP product is now a chain of `hyp3_gamma.__main__:rtc` + `asf_tools.water_map:hyp3` + `asf_tools.flood_depth:hyp3`