### PR TITLE
Set phase filter parameter minumum to exclusive

### DIFF
--- a/hyp3_gamma/__main__.py
+++ b/hyp3_gamma/__main__.py
@@ -114,9 +114,9 @@ def rtc():
 
 def phase_filter_valid_range(x: str) -> float:
     x = float(x)
-    if 0.0 <= x <= 1.0:
+    if 0.0 < x <= 1.0:
         return x
-    raise ValueError(f'{x} not in range [0.0, 1.0]')
+    raise ValueError(f'{x} not in range (0.0, 1.0]')
 
 
 def insar():


### PR DESCRIPTION
```
$ adf 20230227_20230311.diff0.man 20230227_20230311.diff0.man.adf 20230227_20230311.adf.cc 3392 0.0 - 5
*** Adaptive interferogram bandpass filter based on the power spectral density ***
...
ERROR: invalid value for filter exponent:    0.000
```


```ipython
n [1]: def phase_filter_valid_range(x: str) -> float:
   ...:     x = float(x)
   ...:     if 0.0 < x <= 1.0:
   ...:         return x
   ...:     raise ValueError(f'{x} not in range (0.0, 1.0]')
   ...: 

In [2]: phase_filter_valid_range(0.0)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
...
ValueError: 0.0 not in range (0.0, 1.0]
```

For ranges in "maths", convention is `()` for exclusive endpoints, `[]` for inclusive:
https://stackoverflow.com/questions/4396290/what-does-this-square-bracket-and-parenthesis-bracket-notation-mean-first1-last