### PR TITLE
Fix RTC README whitespace

### DIFF
--- a/hyp3_gamma/metadata/templates/macros.j2
+++ b/hyp3_gamma/metadata/templates/macros.j2
@@ -41,7 +41,9 @@
     {%- endif %}
 {% endmacro %}
 {% macro cop_exemption(dem_name) %}
-    {% if dem_name == 'GLO-30' -%}
-        The Copernicus DEM GLO-30 does not have coverage over Armenia or Azerbaijan. For products located where these gaps exist, the Copernicus DEM GLO-90 (90-meter resolution) is used to fill the missing coverage.
-    {%- endif %}
+{% if dem_name == 'GLO-30' %}
+
+
+The Copernicus DEM GLO-30 does not have coverage over Armenia or Azerbaijan. For products located where these gaps exist, the Copernicus DEM GLO-90 (90-meter resolution) is used to fill the missing coverage.
+{%- endif %}
 {% endmacro %}

--- a/hyp3_gamma/metadata/templates/macros.j2
+++ b/hyp3_gamma/metadata/templates/macros.j2
@@ -41,9 +41,7 @@
     {%- endif %}
 {% endmacro %}
 {% macro cop_exemption(dem_name) %}
-{% if dem_name == 'GLO-30' %}
-
-
-The Copernicus DEM GLO-30 does not have coverage over Armenia or Azerbaijan. For products located where these gaps exist, the Copernicus DEM GLO-90 (90-meter resolution) is used to fill the missing coverage.
-{%- endif %}
+    {% if dem_name == 'GLO-30' -%}
+        The Copernicus DEM GLO-30 does not have coverage over Armenia or Azerbaijan. For products located where these gaps exist, the Copernicus DEM GLO-90 (90-meter resolution) is used to fill the missing coverage.
+    {%- endif %}
 {% endmacro %}

--- a/hyp3_gamma/metadata/templates/rtc/readme.md.txt.j2
+++ b/hyp3_gamma/metadata/templates/rtc/readme.md.txt.j2
@@ -101,9 +101,7 @@ The Digital Elevation Model (DEM) used for RTC processing can optionally be incl
 
 The source DEM has a geoid correction applied before it is used for RTC, so elevation values in this file will differ from the source DEM. It is provided in the same pixel spacing/alignment as the RTC product. **The pixel spacing of the DEM included in the product package is not a reflection of the resolution of the source DEM, which is resampled to match the pixel spacing of the RTC product.** The pixel spacing of the adjusted DEM included in this product package is {{ pixel_spacing|int }} meters.
 
-The DEM used for this product is {{ dem_name }}. The DEM has a native pixel spacing of {{ dem_pixel_spacing(dem_name) }}. {{ dem_blurb(dem_name) }}
-
-{{ cop_exemption(dem_name) }}
+The DEM used for this product is {{ dem_name }}. The DEM has a native pixel spacing of {{ dem_pixel_spacing(dem_name) }}. {{ dem_blurb(dem_name) }}{{ cop_exemption(dem_name) }}
 
 {% if dem_blurb(dem_name) %}
 *Refer to the _dem.tif.xml file for additional information about the specific DEM included with this product, including use and citation requirements.*

--- a/hyp3_gamma/metadata/templates/rtc/readme.md.txt.j2
+++ b/hyp3_gamma/metadata/templates/rtc/readme.md.txt.j2
@@ -101,7 +101,11 @@ The Digital Elevation Model (DEM) used for RTC processing can optionally be incl
 
 The source DEM has a geoid correction applied before it is used for RTC, so elevation values in this file will differ from the source DEM. It is provided in the same pixel spacing/alignment as the RTC product. **The pixel spacing of the DEM included in the product package is not a reflection of the resolution of the source DEM, which is resampled to match the pixel spacing of the RTC product.** The pixel spacing of the adjusted DEM included in this product package is {{ pixel_spacing|int }} meters.
 
-The DEM used for this product is {{ dem_name }}. The DEM has a native pixel spacing of {{ dem_pixel_spacing(dem_name) }}. {{ dem_blurb(dem_name) }}{{ cop_exemption(dem_name) }}
+The DEM used for this product is {{ dem_name }}. The DEM has a native pixel spacing of {{ dem_pixel_spacing(dem_name) }}. {{ dem_blurb(dem_name) }}
+{% if dem_name == 'GLO-30' %}
+
+{{ cop_exemption(dem_name) }}
+{% endif %}
 
 {% if dem_blurb(dem_name) %}
 *Refer to the _dem.tif.xml file for additional information about the specific DEM included with this product, including use and citation requirements.*


### PR DESCRIPTION
Minor futzing with the Jinja gets both COP30 and legacy dems to look right. 