### PR TITLE
Revert "Temporarily pin `hyp3lib` to `develop` branch"

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,5 +29,4 @@ dependencies:
   # - lxml
   - pip:
     - lxml==4.8.0
-    # TODO revert after done testing hyp3-lib changes:
-    - git+https://github.com/ASFHyP3/hyp3-lib.git@develop
+    - hyp3lib==1.7.0


### PR DESCRIPTION
Reverts ASFHyP3/hyp3-gamma#521

This can be merged when I'm done testing the `hyp3lib` orbit fetching changes in `hyp3-test`.