### PR TITLE
Use the new orbit fetching interface

### DIFF
--- a/hyp3_gamma/insar/ifm_sentinel.py
+++ b/hyp3_gamma/insar/ifm_sentinel.py
@@ -362,7 +362,9 @@ def insar_sentinel_gamma(reference_file, secondary_file, rlooks=20, alooks=4, in
     orbit_files = []
     for granule in (reference_file, secondary_file):
         log.info(f'Downloading orbit file for {granule}')
-        orbit_file, provider = downloadSentinelOrbitFile(granule)
+        # TODO decide if we want a more robust interface for passing ESA creds, similar to Earthdata creds
+        esa_credentials = (os.environ['ESA_USERNAME'], os.environ['ESA_PASSWORD'])
+        orbit_file, provider = downloadSentinelOrbitFile(granule, esa_credentials=esa_credentials)
         log.info(f'Got orbit file {orbit_file} from provider {provider}')
         par_s1_slc_single(granule, pol, os.path.abspath(orbit_file))
         orbit_files.append(orbit_file)

--- a/hyp3_gamma/insar/ifm_sentinel.py
+++ b/hyp3_gamma/insar/ifm_sentinel.py
@@ -361,7 +361,9 @@ def insar_sentinel_gamma(reference_file, secondary_file, rlooks=20, alooks=4, in
     log.info("Starting par_S1_SLC")
     orbit_files = []
     for granule in (reference_file, secondary_file):
-        orbit_file, _ = downloadSentinelOrbitFile(granule)
+        log.info(f'Downloading orbit file for {granule}')
+        orbit_file, provider = downloadSentinelOrbitFile(granule)
+        log.info(f'Got orbit file {orbit_file} from provider {provider}')
         par_s1_slc_single(granule, pol, os.path.abspath(orbit_file))
         orbit_files.append(orbit_file)
 

--- a/hyp3_gamma/rtc/rtc_sentinel.py
+++ b/hyp3_gamma/rtc/rtc_sentinel.py
@@ -323,7 +323,9 @@ def rtc_sentinel_gamma(safe_dir: str, resolution: float = 30.0, radiometry: str 
     polarizations = get_polarizations(granule, skip_cross_pol)
 
     try:
-        orbit_file, _ = downloadSentinelOrbitFile(granule)
+        log.info(f'Downloading orbit file for {granule}')
+        orbit_file, provider = downloadSentinelOrbitFile(granule)
+        log.info(f'Got orbit file {orbit_file} from provider {provider}')
     except OrbitDownloadError as e:
         log.warning(e)
         log.warning(f'Proceeding using original predicted orbit data included with {granule}')

--- a/hyp3_gamma/rtc/rtc_sentinel.py
+++ b/hyp3_gamma/rtc/rtc_sentinel.py
@@ -324,7 +324,9 @@ def rtc_sentinel_gamma(safe_dir: str, resolution: float = 30.0, radiometry: str 
 
     try:
         log.info(f'Downloading orbit file for {granule}')
-        orbit_file, provider = downloadSentinelOrbitFile(granule)
+        # TODO decide if we want a more robust interface for passing ESA creds, similar to Earthdata creds
+        esa_credentials = (os.environ['ESA_USERNAME'], os.environ['ESA_PASSWORD'])
+        orbit_file, provider = downloadSentinelOrbitFile(granule, esa_credentials=esa_credentials)
         log.info(f'Got orbit file {orbit_file} from provider {provider}')
     except OrbitDownloadError as e:
         log.warning(e)


### PR DESCRIPTION
This will allow testing the new `hyp3lib` orbit fetching implementation on `hyp3-test`. Afterwards, we can either revert this PR (if we're not going to release the new orbit fetching implementation), or finalize the implementation from this PR, add a Changelog entry, and release the changes.