### PR TITLE
Adjust dem buffer to avoid clipping granules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [9.0.6]
 ### Changed
-- Output DEM is now buffered 25 km
+- Output DEM is now buffered by 25 km
 
 ## [9.0.5]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.6]
+### Changed
+- Output DEM is now buffered by 0.50 degrees
+
 ## [9.0.5]
 ### Changed
 - Move code over from `hyp3lib` that is only used in `hyp3-gamma` and bump `hyp3lib` to `v4.0.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [9.0.6]
 ### Changed
-- Output DEM is now buffered by 0.50 degrees
+- Output DEM is now buffered 25 km
 
 ## [9.0.5]
 ### Changed

--- a/hyp3_gamma/dem.py
+++ b/hyp3_gamma/dem.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from subprocess import PIPE, run
 
+import numpy as np
 from hyp3lib import dem
 from osgeo import ogr
 
@@ -25,6 +26,36 @@ def get_geometry_from_kml(kml_file: str) -> ogr.Geometry:
     return ogr.CreateGeometryFromJson(json.dumps(geometry))
 
 
+def get_buffer_distance(lat_in_dd: float, buffer_in_km: float) -> tuple[float, float]:
+    """Given a latitude and a buffer distance in kilometers, return the
+    corresponding buffer distance in degrees for both longitude and latitude.
+
+    Calculation from:
+    https://en.wikipedia.org/wiki/Longitude#Length_of_a_degree_of_longitude
+    https://en.wikipedia.org/wiki/Latitude#Length_of_a_degree_of_latitude
+
+    Args:
+        lat_in_dd: Latitude to perform the calculation at in decimal degrees
+        buffer_in_km: Buffer distance in kilometers
+
+    Returns:
+        A tuple containing the buffer distance in degrees for longitude and latitude
+    """
+    assert lat_in_dd > -90 and lat_in_dd < 90, 'Latitude must be between -90 and 90 degrees'
+    one_lat_degree_length = 111.32
+    buffer_lat_in_dd = buffer_in_km / one_lat_degree_length
+    buffer_lon_in_dd = buffer_in_km / (one_lat_degree_length * np.cos(np.deg2rad(lat_in_dd)))
+    return buffer_lon_in_dd, buffer_lat_in_dd
+
+
+def get_buffer_in_degrees_for(geometry: ogr.Geometry, buffer_distance_km: float) -> float:
+    _, _, min_lat, max_lat = geometry.GetEnvelope()
+    geometry_lat = max(np.abs(min_lat), np.abs(max_lat))
+    lon_buffer, _ = get_buffer_distance(geometry_lat, buffer_distance_km)[0]
+
+    return lon_buffer
+
+
 def utm_from_lon_lat(lon: float, lat: float) -> int:
     hemisphere = 32600 if lat >= 0 else 32700
     zone = int(lon // 6 + 30) % 60 + 1
@@ -35,7 +66,7 @@ def prepare_dem_geotiff(output_name: str, geometry: ogr.Geometry, pixel_size: fl
     """Create a DEM mosaic GeoTIFF covering a given geometry.
 
     The DEM mosaic is assembled from the Copernicus GLO-30 Public DEM. The output GeoTIFF covers the input geometry
-    buffered by 0.50 degrees, is projected to the UTM zone of the geometry centroid, and has a pixel size of 30m.
+    buffered by 15km, is projected to the UTM zone of the geometry centroid, and has a pixel size of 30m.
 
     Args:
         output_name: Path for the output GeoTIFF
@@ -45,7 +76,14 @@ def prepare_dem_geotiff(output_name: str, geometry: ogr.Geometry, pixel_size: fl
     """
     centroid = geometry.Centroid()
 
+    buffer_distance_km = 15.0
+    buffer_in_degrees = get_buffer_in_degrees_for(geometry, buffer_distance_km)
+
     epsg_code = utm_from_lon_lat(centroid.GetX(), centroid.GetY())
     dem.prepare_dem_geotiff(
-        Path(output_name), geometry, epsg_code=epsg_code, pixel_size=pixel_size, buffer_size_in_degrees=0.50
+        Path(output_name),
+        geometry,
+        epsg_code=epsg_code,
+        pixel_size=pixel_size,
+        buffer_size_in_degrees=buffer_in_degrees,
     )

--- a/hyp3_gamma/dem.py
+++ b/hyp3_gamma/dem.py
@@ -47,5 +47,5 @@ def prepare_dem_geotiff(output_name: str, geometry: ogr.Geometry, pixel_size: fl
 
     epsg_code = utm_from_lon_lat(centroid.GetX(), centroid.GetY())
     dem.prepare_dem_geotiff(
-        Path(output_name), geometry, epsg_code=epsg_code, pixel_size=pixel_size, buffer_size_in_degrees=0.30
+        Path(output_name), geometry, epsg_code=epsg_code, pixel_size=pixel_size, buffer_size_in_degrees=0.50
     )

--- a/hyp3_gamma/dem.py
+++ b/hyp3_gamma/dem.py
@@ -51,7 +51,7 @@ def get_buffer_distance(lat_in_dd: float, buffer_in_km: float) -> tuple[float, f
 def get_buffer_in_degrees_for(geometry: ogr.Geometry, buffer_distance_km: float) -> float:
     _, _, min_lat, max_lat = geometry.GetEnvelope()
     geometry_lat = max(np.abs(min_lat), np.abs(max_lat))
-    lon_buffer, _ = get_buffer_distance(geometry_lat, buffer_distance_km)[0]
+    lon_buffer, _ = get_buffer_distance(geometry_lat, buffer_distance_km)
 
     return lon_buffer
 

--- a/hyp3_gamma/dem.py
+++ b/hyp3_gamma/dem.py
@@ -35,7 +35,7 @@ def prepare_dem_geotiff(output_name: str, geometry: ogr.Geometry, pixel_size: fl
     """Create a DEM mosaic GeoTIFF covering a given geometry.
 
     The DEM mosaic is assembled from the Copernicus GLO-30 Public DEM. The output GeoTIFF covers the input geometry
-    buffered by 0.15 degrees, is projected to the UTM zone of the geometry centroid, and has a pixel size of 30m.
+    buffered by 0.50 degrees, is projected to the UTM zone of the geometry centroid, and has a pixel size of 30m.
 
     Args:
         output_name: Path for the output GeoTIFF

--- a/hyp3_gamma/dem.py
+++ b/hyp3_gamma/dem.py
@@ -53,7 +53,7 @@ def get_buffer_in_degrees_for(geometry: ogr.Geometry, buffer_distance_km: float)
     geometry_lat = max(np.abs(min_lat), np.abs(max_lat))
     lon_buffer, _ = get_buffer_distance(geometry_lat, buffer_distance_km)
 
-    return lon_buffer
+    return round(lon_buffer, 2)
 
 
 def utm_from_lon_lat(lon: float, lat: float) -> int:

--- a/hyp3_gamma/dem.py
+++ b/hyp3_gamma/dem.py
@@ -47,5 +47,5 @@ def prepare_dem_geotiff(output_name: str, geometry: ogr.Geometry, pixel_size: fl
 
     epsg_code = utm_from_lon_lat(centroid.GetX(), centroid.GetY())
     dem.prepare_dem_geotiff(
-        Path(output_name), geometry, epsg_code=epsg_code, pixel_size=pixel_size, buffer_size_in_degrees=0.20
+        Path(output_name), geometry, epsg_code=epsg_code, pixel_size=pixel_size, buffer_size_in_degrees=0.30
     )

--- a/hyp3_gamma/dem.py
+++ b/hyp3_gamma/dem.py
@@ -66,7 +66,7 @@ def prepare_dem_geotiff(output_name: str, geometry: ogr.Geometry, pixel_size: fl
     """Create a DEM mosaic GeoTIFF covering a given geometry.
 
     The DEM mosaic is assembled from the Copernicus GLO-30 Public DEM. The output GeoTIFF covers the input geometry
-    buffered by 15km, is projected to the UTM zone of the geometry centroid, and has a pixel size of 30m.
+    buffered by 25km, is projected to the UTM zone of the geometry centroid, and has a pixel size of 30m.
 
     Args:
         output_name: Path for the output GeoTIFF
@@ -76,7 +76,7 @@ def prepare_dem_geotiff(output_name: str, geometry: ogr.Geometry, pixel_size: fl
     """
     centroid = geometry.Centroid()
 
-    buffer_distance_km = 15.0
+    buffer_distance_km = 25.0
     buffer_in_degrees = get_buffer_in_degrees_for(geometry, buffer_distance_km)
 
     epsg_code = utm_from_lon_lat(centroid.GetX(), centroid.GetY())

--- a/hyp3_gamma/dem.py
+++ b/hyp3_gamma/dem.py
@@ -47,5 +47,5 @@ def prepare_dem_geotiff(output_name: str, geometry: ogr.Geometry, pixel_size: fl
 
     epsg_code = utm_from_lon_lat(centroid.GetX(), centroid.GetY())
     dem.prepare_dem_geotiff(
-        Path(output_name), geometry, epsg_code=epsg_code, pixel_size=pixel_size, buffer_size_in_degrees=0.15
+        Path(output_name), geometry, epsg_code=epsg_code, pixel_size=pixel_size, buffer_size_in_degrees=0.20
     )

--- a/tests/data/far-north.kml
+++ b/tests/data/far-north.kml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xmlns:xfdu="urn:ccsds:schema:xfdu:1" xmlns:safe="http://www.esa.int/safe/sentinel-1.0" xmlns:s1="http://www.esa.int/safe/sentinel-1.0/sentinel-1" xmlns:s1sar="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar" xmlns:s1sarl1="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-1" xmlns:s1sarl2="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+  <Document>
+    <name>Sentinel-1 Map Overlay</name>
+    <Folder>
+      <name>Sentinel-1 Scene Overlay</name>
+      <GroundOverlay>
+        <name>Sentinel-1 Image Overlay</name>
+        <Icon>
+          <href>quick-look.png</href>
+        </Icon>
+        <gx:LatLonQuad>
+          <coordinates>-86.534836,75.073479 -95.139221,75.713623 -93.594521,77.293640 -84.066757,76.592140</coordinates>
+        </gx:LatLonQuad>
+      </GroundOverlay>
+    </Folder>
+  </Document>
+</kml>

--- a/tests/data/south-pole.kml
+++ b/tests/data/south-pole.kml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xmlns:xfdu="urn:ccsds:schema:xfdu:1" xmlns:safe="http://www.esa.int/safe/sentinel-1.0" xmlns:s1="http://www.esa.int/safe/sentinel-1.0/sentinel-1" xmlns:s1sar="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar" xmlns:s1sarl1="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-1" xmlns:s1sarl2="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-2" xmlns:gx="http://www.google.com/kml/ext/2.2">
+  <Document>
+    <name>Sentinel-1 Map Overlay</name>
+    <Folder>
+      <name>Sentinel-1 Scene Overlay</name>
+      <GroundOverlay>
+        <name>Sentinel-1 Image Overlay</name>
+        <Icon>
+          <href>quick-look.png</href>
+        </Icon>
+        <gx:LatLonQuad>
+          <coordinates>-131.586761,-78.637230 -131.655701,-76.397514 -124.665192,-76.290108 -123.280869,-78.509460</coordinates>
+        </gx:LatLonQuad>
+      </GroundOverlay>
+    </Folder>
+  </Document>
+</kml>

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -153,7 +153,7 @@ def test_prepare_dem_geotiff_antimeridian(tmp_path):
     'filename,expected_buffer', [('south-pole', 1.14), ('far-north', 1.02), ('alaska', 0.69), ('antimeridian', 0.36)]
 )
 def test_get_buffer_in_degrees(test_data_dir, filename, expected_buffer):
-    south_pole_geometry = dem.get_geometry_from_kml(test_data_dir / f'{filename}.kml')
+    geometry = dem.get_geometry_from_kml(test_data_dir / f'{filename}.kml')
 
-    buffer = dem.get_buffer_in_degrees_for(south_pole_geometry, 25)
+    buffer = dem.get_buffer_in_degrees_for(geometry, 25)
     assert buffer == expected_buffer

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -121,8 +121,8 @@ def test_prepare_dem_geotiff(tmp_path):
     assert dem_geotiff.exists()
 
     info = gdal.Info(str(dem_geotiff), format='json')
-    assert info['geoTransform'] == [159720.0, 60.0, 0.0, 1256520.0, 0.0, -60.0]
-    assert info['size'] == [2216, 3120]
+    assert info['geoTransform'] == [189780.0, 60.0, 0.0, 1226700.0, 0.0, -60.0]
+    assert info['size'] == [1218, 2126]
 
 
 def test_prepare_dem_geotiff_antimeridian(tmp_path):
@@ -145,5 +145,5 @@ def test_prepare_dem_geotiff_antimeridian(tmp_path):
     assert dem_geotiff.exists()
 
     info = gdal.Info(str(dem_geotiff), format='json')
-    assert info['geoTransform'] == [218760.0, 30.0, 0.0, 5774070.0, 0.0, -30.0]
-    assert info['size'] == [4809, 4259]
+    assert info['geoTransform'] == [229290.0, 30.0, 0.0, 5758950.0, 0.0, -30.0]
+    assert info['size'] == [4127, 3259]

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -147,3 +147,17 @@ def test_prepare_dem_geotiff_antimeridian(tmp_path):
     info = gdal.Info(str(dem_geotiff), format='json')
     assert info['geoTransform'] == [229290.0, 30.0, 0.0, 5758950.0, 0.0, -30.0]
     assert info['size'] == [4127, 3259]
+
+
+def test_get_buffer_in_degrees(slc_geometry):
+    buffer = dem.get_buffer_in_degrees_for(slc_geometry, 25)
+    assert buffer == 1
+
+
+@pytest.fixture
+def slc_geometry(test_data_dir):
+    # S1A_IW_SLC__1SSH_20250508T084854_20250508T084921_059100_07551F_7194
+    kml = test_data_dir / 'south-pole.kml'
+    geometry = dem.get_geometry_from_kml(kml)
+
+    return geometry

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -121,7 +121,7 @@ def test_prepare_dem_geotiff(tmp_path):
     assert dem_geotiff.exists()
 
     info = gdal.Info(str(dem_geotiff), format='json')
-    assert info['geoTransform'] == [198480.0, 60.0, 0.0, 1218060.0, 0.0, -60.0]
+    assert info['geoTransform'] == [159720.0, 60.0, 0.0, 1218060.0, 0.0, -60.0]
     assert info['size'] == [928, 1839]
 
 
@@ -145,5 +145,5 @@ def test_prepare_dem_geotiff_antimeridian(tmp_path):
     assert dem_geotiff.exists()
 
     info = gdal.Info(str(dem_geotiff), format='json')
-    assert info['geoTransform'] == [245280.0, 30.0, 0.0, 5735850.0, 0.0, -30.0]
+    assert info['geoTransform'] == [218760.0, 30.0, 0.0, 5774070.0, 0.0, -30.0]
     assert info['size'] == [3084, 1730]

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -149,15 +149,11 @@ def test_prepare_dem_geotiff_antimeridian(tmp_path):
     assert info['size'] == [4119, 3247]
 
 
-def test_get_buffer_in_degrees(slc_geometry):
-    buffer = dem.get_buffer_in_degrees_for(slc_geometry, 25)
-    assert buffer == 1.14
+@pytest.mark.parametrize(
+    'filename,expected_buffer', [('south-pole', 1.14), ('far-north', 1.02), ('alaska', 0.69), ('antimeridian', 0.36)]
+)
+def test_get_buffer_in_degrees(test_data_dir, filename, expected_buffer):
+    south_pole_geometry = dem.get_geometry_from_kml(test_data_dir / f'{filename}.kml')
 
-
-@pytest.fixture
-def slc_geometry(test_data_dir):
-    # S1A_IW_SLC__1SSH_20250508T084854_20250508T084921_059100_07551F_7194
-    kml = test_data_dir / 'south-pole.kml'
-    geometry = dem.get_geometry_from_kml(kml)
-
-    return geometry
+    buffer = dem.get_buffer_in_degrees_for(south_pole_geometry, 25)
+    assert buffer == expected_buffer

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -121,8 +121,8 @@ def test_prepare_dem_geotiff(tmp_path):
     assert dem_geotiff.exists()
 
     info = gdal.Info(str(dem_geotiff), format='json')
-    assert info['geoTransform'] == [189780.0, 60.0, 0.0, 1226700.0, 0.0, -60.0]
-    assert info['size'] == [1218, 2126]
+    assert info['geoTransform'] == [189600.0, 60.0, 0.0, 1226820.0, 0.0, -60.0]
+    assert info['size'] == [1223, 2131]
 
 
 def test_prepare_dem_geotiff_antimeridian(tmp_path):
@@ -145,13 +145,13 @@ def test_prepare_dem_geotiff_antimeridian(tmp_path):
     assert dem_geotiff.exists()
 
     info = gdal.Info(str(dem_geotiff), format='json')
-    assert info['geoTransform'] == [229290.0, 30.0, 0.0, 5758950.0, 0.0, -30.0]
-    assert info['size'] == [4127, 3259]
+    assert info['geoTransform'] == [229410.0, 30.0, 0.0, 5758770.0, 0.0, -30.0]
+    assert info['size'] == [4119, 3247]
 
 
 def test_get_buffer_in_degrees(slc_geometry):
     buffer = dem.get_buffer_in_degrees_for(slc_geometry, 25)
-    assert buffer == 1
+    assert buffer == 1.14
 
 
 @pytest.fixture

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -122,7 +122,7 @@ def test_prepare_dem_geotiff(tmp_path):
 
     info = gdal.Info(str(dem_geotiff), format='json')
     assert info['geoTransform'] == [159720.0, 60.0, 0.0, 1256520.0, 0.0, -60.0]
-    assert info['size'] == [928, 1839]
+    assert info['size'] == [2216, 3120]
 
 
 def test_prepare_dem_geotiff_antimeridian(tmp_path):

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -121,7 +121,7 @@ def test_prepare_dem_geotiff(tmp_path):
     assert dem_geotiff.exists()
 
     info = gdal.Info(str(dem_geotiff), format='json')
-    assert info['geoTransform'] == [159720.0, 60.0, 0.0, 1218060.0, 0.0, -60.0]
+    assert info['geoTransform'] == [159720.0, 60.0, 0.0, 1256520.0, 0.0, -60.0]
     assert info['size'] == [928, 1839]
 
 
@@ -146,4 +146,4 @@ def test_prepare_dem_geotiff_antimeridian(tmp_path):
 
     info = gdal.Info(str(dem_geotiff), format='json')
     assert info['geoTransform'] == [218760.0, 30.0, 0.0, 5774070.0, 0.0, -30.0]
-    assert info['size'] == [3084, 1730]
+    assert info['size'] == [4809, 4259]


### PR DESCRIPTION
Find a buffer when preparing the DEM that won't clip the end product. There are a handful of granules that we've seen this at very northern and southern latitutdes (`S1A_IW_SLC__1SSH_20250508T084854_20250508T084921_059100_07551F_7194`, `S1A_IW_SLC__1SDH_20250508T125942_20250508T130009_059103_075538_2141`, `S1C_IW_GRDH_1SDV_20250430T005033_20250430T005105_002115_004795_5091`, `S1A_IW_SLC__1SDV_20250424T013543_20250424T013611_058892_074CDA_7498`, 
`S1C_IW_SLC__1SDV_20250424T040225_20250424T040252_002030_004263_5DBF`)

TODO: 

- [x] Determine a buffer that avoids clipping the example granules
- [x] Update [hyp3_gamma/dem.py](https://github.com/ASFHyP3/hyp3-gamma/blob/develop/hyp3_gamma/dem.py#L34-L51) with the new buffer
- [x] Update [tests/test_dem.py](https://github.com/ASFHyP3/hyp3-gamma/blob/develop/tests/test_dem.py) to pass with the new buffer
- [ ] Update Golden Tests if needed (?)  