### PR TITLE
do phase unwrapping in 2x2 patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.9]
+
+### Changed
+- InSAR phase wrapping with `mcf` is now always done in 2 range patches and 2 azimuth patches
+- InSAR processing now removes the `YYYYMMDD` directories used to mosaic the input SLCs after mosaicing is complete.
+
 ## [9.0.8]
 
 This is a maintenance release that includes various dependency upgrades.

--- a/hyp3_gamma/insar/ifm_sentinel.py
+++ b/hyp3_gamma/insar/ifm_sentinel.py
@@ -453,6 +453,9 @@ def insar_sentinel_gamma(
     slc_copy_s1_full_sw(wrk, secondary, 'SLC_TAB', burst_tab2, mode=2, raml=rlooks, azml=alooks)
     os.chdir('..')
 
+    shutil.rmtree(reference)
+    shutil.rmtree(secondary)
+
     # Interferogram creation, matching, refinement
     log.info('Starting interf_pwr_s1_lt_tops_proc.py 0')
     hgt = f'DEM/HGT_SAR_{rlooks}_{alooks}'

--- a/hyp3_gamma/insar/unwrapping_geocoding.py
+++ b/hyp3_gamma/insar/unwrapping_geocoding.py
@@ -244,7 +244,6 @@ def unwrapping_geocoding(
         log.error(f'ERROR: Unable to find offset file {offit}')
 
     width = get_parameter(offit, 'interferogram_width')
-    lines = get_parameter(offit, 'interferogram_azimuth_lines')
     mwidth = get_parameter(mmli + '.par', 'range_samples')
     mlines = get_parameter(mmli + '.par', 'azimuth_lines')
     swidth = get_parameter(smli + '.par', 'range_samples')

--- a/hyp3_gamma/insar/unwrapping_geocoding.py
+++ b/hyp3_gamma/insar/unwrapping_geocoding.py
@@ -298,16 +298,9 @@ def unwrapping_geocoding(
 
     height = get_height_at_pixel(f'DEM/HGT_SAR_{rlooks}_{alooks}', int(mlines), int(mwidth), ref_azlin, ref_rpix)
 
-    # unwrap very large interferograms in multiple patches to keep memory requirement under 31,600 MB
-    # https://github.com/ASFHyP3/hyp3-gamma/issues/316
-    if int(width) * int(lines) < 54000000:
-        range_patches = 1
-    else:
-        range_patches = 2
-
     mcf_log = execute(
         f'mcf {ifgf}.adf {ifgname}.adf.cc {out_file} {ifgname}.adf.unw {width} {trimode} 0 0'
-        f' - - {range_patches} 1 - {ref_rpix} {ref_azlin} 1',
+        f' - - 2 2 - {ref_rpix} {ref_azlin} 1',
         uselogging=True,
     )
 


### PR DESCRIPTION
Reduces memory requirement under 16 GB for S1 InSAR jobs, allowing them to be more cost-efficient when run in HyP3.

See https://github.com/ASFHyP3/hyp3-gamma/issues/316 for some discussion on the impact of doing phase unwrapping in patches.

The failing test is related to `setuptools` v82.0.0 dropping `pkg_resources`, see https://github.com/pypa/setuptools/issues/5174 . It doesn't impact the built container (which ends up with setuptools v59.6.0); it only impacts the environment when building from conda during development/testing (which ends up with setuptools v82.0.1).

I took a random sample of 190 successful INSAR_GAMMA jobs from the last year and ran them all successfully on `r8id.large` instances (15,500 MB RAM, 118 GB disk). I did the same for 11 of the very-large SLCs over Hawaii from #316 .