### PR TITLE
Release v9.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.9]
+
+### Changed
+- InSAR phase wrapping with `mcf` is now always done in 2 range patches and 2 azimuth patches
+- InSAR processing now removes the `YYYYMMDD` directories used to mosaic the input SLCs after mosaicing is complete.
+
 ## [9.0.8]
 
 This is a maintenance release that includes various dependency upgrades.

--- a/hyp3_gamma/insar/ifm_sentinel.py
+++ b/hyp3_gamma/insar/ifm_sentinel.py
@@ -453,6 +453,9 @@ def insar_sentinel_gamma(
     slc_copy_s1_full_sw(wrk, secondary, 'SLC_TAB', burst_tab2, mode=2, raml=rlooks, azml=alooks)
     os.chdir('..')
 
+    shutil.rmtree(reference)
+    shutil.rmtree(secondary)
+
     # Interferogram creation, matching, refinement
     log.info('Starting interf_pwr_s1_lt_tops_proc.py 0')
     hgt = f'DEM/HGT_SAR_{rlooks}_{alooks}'

--- a/hyp3_gamma/insar/unwrapping_geocoding.py
+++ b/hyp3_gamma/insar/unwrapping_geocoding.py
@@ -244,7 +244,6 @@ def unwrapping_geocoding(
         log.error(f'ERROR: Unable to find offset file {offit}')
 
     width = get_parameter(offit, 'interferogram_width')
-    lines = get_parameter(offit, 'interferogram_azimuth_lines')
     mwidth = get_parameter(mmli + '.par', 'range_samples')
     mlines = get_parameter(mmli + '.par', 'azimuth_lines')
     swidth = get_parameter(smli + '.par', 'range_samples')

--- a/hyp3_gamma/insar/unwrapping_geocoding.py
+++ b/hyp3_gamma/insar/unwrapping_geocoding.py
@@ -298,16 +298,9 @@ def unwrapping_geocoding(
 
     height = get_height_at_pixel(f'DEM/HGT_SAR_{rlooks}_{alooks}', int(mlines), int(mwidth), ref_azlin, ref_rpix)
 
-    # unwrap very large interferograms in multiple patches to keep memory requirement under 31,600 MB
-    # https://github.com/ASFHyP3/hyp3-gamma/issues/316
-    if int(width) * int(lines) < 54000000:
-        range_patches = 1
-    else:
-        range_patches = 2
-
     mcf_log = execute(
         f'mcf {ifgf}.adf {ifgname}.adf.cc {out_file} {ifgname}.adf.unw {width} {trimode} 0 0'
-        f' - - {range_patches} 1 - {ref_rpix} {ref_azlin} 1',
+        f' - - 2 2 - {ref_rpix} {ref_azlin} 1',
         uselogging=True,
     )
 

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -2,5 +2,5 @@ pytest
 pytest-cov
 pytest-console-scripts
 setuptools_scm
-ruff==0.14.2
+ruff==0.14.4
 mypy==1.18.2

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -2,5 +2,5 @@ pytest
 pytest-cov
 pytest-console-scripts
 setuptools_scm
-ruff==0.14.4
-mypy==1.18.2
+ruff==0.14.7
+mypy==1.19.0


### PR DESCRIPTION
This release breaks phase unwrapping into multiple patches to reduce the required memory of INSAR_GAMMA jobs, allowing them to be run more cost-efficiently.

Unsurprisingly, the InSAR golden test detected phase unwrapping differences in 4 of 12 interferograms. Here's the most dramatic of them, the only one with a clear discontinuity along the patch boundary: https://github.com/ASFHyP3/hyp3-testing/actions/runs/24417205390

Prod:
<img width="1973" height="1194" alt="Screenshot from 2026-04-14 14-13-11" src="https://github.com/user-attachments/assets/7bc95830-4c46-4920-8f92-c6d35f81c194" />

Test:
<img width="1973" height="1194" alt="Screenshot from 2026-04-14 14-13-05" src="https://github.com/user-attachments/assets/d2f12726-b8d2-4cb9-bfe1-ef91c8311b0e" />

I'd previously only seen the patch boundary be obvious over water, as shown in the screenshots in #316 .

I'm prepared to proceed. @jhkennedy @AndrewPlayer3 @mfangaritav is that one error case enough to give anyone pause about releasing?