### PR TITLE
remove generation of files that don't contribute to final InSAR product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.10]
+
+### Changed
+- Slightly improved runtime of InSAR processing by removing generations of files that didn't contribute to the final InSAR product
+
 ## [9.0.9]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [9.0.9]
 
 ### Changed
-- Slightly improved runtime of InSAR processing by removing generations of files that didn't contribute to the final InSAR product
+- Slightly improved runtime of InSAR processing by removing generation of files that didn't contribute to the final InSAR product
 
 ## [9.0.8]
 

--- a/hyp3_gamma/insar/interf_pwr_s1_lt_tops_proc.py
+++ b/hyp3_gamma/insar/interf_pwr_s1_lt_tops_proc.py
@@ -80,21 +80,12 @@ def coregister_data(
     with open(f'offsetfit{cnt}.log', 'w') as log:
         execute(f'offset_fit offs snr {offi} - - 0.2 1', uselogging=True, logfile=log)
 
-    if cnt < iterations + 1:
-        ifg_diff_sfx = f'it{cnt}'
-    else:
-        ifg_diff_sfx = 'man'
-    execute(
-        f'SLC_diff_intf {reference}.slc {secondary}.rslc {mpar} {srpar} {offi}'
-        f' {ifgname}.sim_unw {ifgname}.diff0.{ifg_diff_sfx} {rlooks} {alooks} 0 0',
-        uselogging=True,
-    )
-
-    width = get_parameter(offi, 'interferogram_width')
-    execute(
-        f'rasmph_pwr {ifgname}.diff0.{ifg_diff_sfx} {reference}.mli {width} - - 3 3',
-        uselogging=True,
-    )
+    if not cnt < iterations + 1:
+        execute(
+            f'SLC_diff_intf {reference}.slc {secondary}.rslc {mpar} {srpar} {offi}'
+            f' {ifgname}.sim_unw {ifgname}.diff0.man {rlooks} {alooks} 0 0',
+            uselogging=True,
+        )
 
     if cnt == 0:
         offit = ifgname + '.off.it'

--- a/hyp3_gamma/insar/interf_pwr_s1_lt_tops_proc.py
+++ b/hyp3_gamma/insar/interf_pwr_s1_lt_tops_proc.py
@@ -8,8 +8,6 @@ import sys
 
 from hyp3lib.execute import execute
 
-from hyp3_gamma.get_parameter import get_parameter
-
 
 log = logging.getLogger(__name__)
 

--- a/hyp3_gamma/insar/par_s1_slc_single.py
+++ b/hyp3_gamma/insar/par_s1_slc_single.py
@@ -92,7 +92,4 @@ def par_s1_slc_single(safe_dir, pol='vv', orbit_file=None):
         for i in range(len(slc)):
             f.write(f'{slc[i]} {par[i]} {top[i]}\n')
 
-    # Make a raster version of swath 3
-    width = get_parameter(f'{acquisition_date}_003.slc.par', 'range_samples')
-    execute(f'rasSLC {acquisition_date}_003.slc {width} 1 0 50 10')
     os.chdir(wrk)

--- a/hyp3_gamma/insar/par_s1_slc_single.py
+++ b/hyp3_gamma/insar/par_s1_slc_single.py
@@ -6,8 +6,6 @@ from hyp3lib import OrbitDownloadError
 from hyp3lib.execute import execute
 from hyp3lib.get_orb import downloadSentinelOrbitFile
 
-from hyp3_gamma.get_parameter import get_parameter
-
 
 def make_cmd(swath, acquisition_date, out_dir, pol=None):
     """Assemble the par_S1_SLC gamma commands

--- a/hyp3_gamma/insar/slc_copy_s1_full_sw.py
+++ b/hyp3_gamma/insar/slc_copy_s1_full_sw.py
@@ -38,10 +38,6 @@ def slc_copy_s1_full_sw(path, slcname, tabin, burst_tab, mode=2, dem=None, dempa
     cmd = 'SLC_mosaic_S1_TOPS {TAB} {SLC}.slc {SLC}.slc.par {RL} {AL}'.format(TAB=tabin, SLC=slcname, RL=raml, AL=azml)
     execute(cmd, uselogging=True)
 
-    width = get_parameter('{}.slc.par'.format(slcname), 'range_samples')
-    cmd = 'rasSLC {}.slc {} 1 0 50 10'.format(slcname, width)
-    execute(cmd, uselogging=True)
-
     cmd = 'multi_S1_TOPS {TAB} {SLC}.mli {SLC}.mli.par {RL} {AL}'.format(TAB=tabin, SLC=slcname, RL=raml, AL=azml)
     execute(cmd, uselogging=True)
 

--- a/hyp3_gamma/insar/unwrapping_geocoding.py
+++ b/hyp3_gamma/insar/unwrapping_geocoding.py
@@ -152,10 +152,6 @@ def data2geotiff(inname, outname, dempar, type_):
     execute(f'data2geotiff {dempar} {inname} {type_} {outname} ', uselogging=True)
 
 
-def create_phase_from_complex(incpx, outfloat, width):
-    execute(f'cpx_to_real {incpx} {outfloat} {width} 4', uselogging=True)
-
-
 def get_water_mask(cc_file, width, lt, demw, demn, dempar):
     """Create water_mask geotiff file based on the cc_file (float binary file)"""
     with TemporaryDirectory() as temp_dir:
@@ -339,16 +335,6 @@ def unwrapping_geocoding(
     log.info('-------------------------------------------------')
 
     geocode_back(mmli, mmli + '.geo', mwidth, lt, demw, demn, 0)
-    geocode_back(smli, smli + '.geo', swidth, lt, demw, demn, 0)
-    geocode_back(
-        f'{ifgname}.sim_unw',
-        f'{ifgname}.sim_unw.geo',
-        width,
-        lt,
-        demw,
-        demn,
-        0,
-    )
     geocode_back(
         f'{ifgname}.adf.unw',
         f'{ifgname}.adf.unw.geo',
@@ -379,15 +365,6 @@ def unwrapping_geocoding(
     )
     geocode_back(f'{ifgname}.cc', f'{ifgname}.cc.geo', width, lt, demw, demn, 0)
     geocode_back(
-        f'{ifgname}.adf.cc',
-        f'{ifgname}.adf.cc.geo',
-        width,
-        lt,
-        demw,
-        demn,
-        0,
-    )
-    geocode_back(
         f'{ifgname}.vert.disp',
         f'{ifgname}.vert.disp.geo',
         width,
@@ -406,16 +383,7 @@ def unwrapping_geocoding(
         0,
     )
 
-    create_phase_from_complex(f'{ifgf}.adf.geo', f'{ifgf}.adf.geo.phase', width)
-
     data2geotiff(mmli + '.geo', mmli + '.geo.tif', dempar, 2)
-    data2geotiff(smli + '.geo', smli + '.geo.tif', dempar, 2)
-    data2geotiff(
-        f'{ifgname}.sim_unw.geo',
-        f'{ifgname}.sim_unw.geo.tif',
-        dempar,
-        2,
-    )
     data2geotiff(
         f'{ifgname}.adf.unw.geo',
         f'{ifgname}.adf.unw.geo.tif',
@@ -428,10 +396,8 @@ def unwrapping_geocoding(
         dempar,
         0,
     )
-    data2geotiff(f'{ifgf}.adf.geo.phase', f'{ifgf}.adf.geo.tif', dempar, 2)
     data2geotiff(f'{ifgf}.adf.bmp.geo', f'{ifgf}.adf.bmp.geo.tif', dempar, 0)
     data2geotiff(f'{ifgname}.cc.geo', f'{ifgname}.cc.geo.tif', dempar, 2)
-    data2geotiff(f'{ifgname}.adf.cc.geo', f'{ifgname}.adf.cc.geo.tif', dempar, 2)
     data2geotiff('DEM/demseg', f'{ifgname}.dem.tif', dempar, 2)
     data2geotiff(
         f'{ifgname}.vert.disp.geo',

--- a/hyp3_gamma/insar/unwrapping_geocoding.py
+++ b/hyp3_gamma/insar/unwrapping_geocoding.py
@@ -243,7 +243,6 @@ def unwrapping_geocoding(
     lines = get_parameter(offit, 'interferogram_azimuth_lines')
     mwidth = get_parameter(mmli + '.par', 'range_samples')
     mlines = get_parameter(mmli + '.par', 'azimuth_lines')
-    swidth = get_parameter(smli + '.par', 'range_samples')
     demw = get_parameter(dempar, 'width')
     demn = get_parameter(dempar, 'nlines')
 

--- a/hyp3_gamma/insar/unwrapping_geocoding.py
+++ b/hyp3_gamma/insar/unwrapping_geocoding.py
@@ -228,7 +228,6 @@ def unwrapping_geocoding(
     ifgname = f'{reference}_{secondary}'
     offit = f'{ifgname}.off.it'
     mmli = reference + '.mli'
-    smli = secondary + '.mli'
 
     if not os.path.isfile(dempar):
         log.error(f'ERROR: Unable to find dem par file {dempar}')


### PR DESCRIPTION
The `ras*` utilities create .bmp files of intermediate rasters; the .bmps aren't used in processing or included in the final output. Presumably they were for human verification while the workflow was being developed.

The `geocode_back` and `data2geotiff` calls near the end of product generation were pruned to just the files potentially included in the output product by `move_output_files` at https://github.com/ASFHyP3/hyp3-gamma/blob/develop/hyp3_gamma/insar/ifm_sentinel.py#L511

`docker run -it -e EARTHDATA_USERNAME=... -e EARTHDATA_PASSWORD=... hyp3-gamma:latest ++proces insar S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8 S1A_IW_SLC__1SSV_20150504T120217_20150504T120229_005771_00769E_EF9A` succeeds from this branch; I'd like to merge to develop and run the golden test to verify there are no issues with all the possible input parameter values.

Edit: Same SLC pair also runs successfully with all the parameters except `looks` flipped to their non-default value